### PR TITLE
Add support for sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "chart.js": "^3.3.2",
         "electron": "^13.0.1",
         "node-fetch": "^2.6.1",
+        "pako": "^2.0.3",
         "papaparse": "^5.3.1",
         "pg": "^8.6.0",
         "react": "^17.0.2",
@@ -26,6 +27,7 @@
     "devDependencies": {
         "@types/electron": "^1.6.10",
         "@types/node-fetch": "^2.5.10",
+        "@types/pako": "^1.0.1",
         "@types/papaparse": "^5.2.5",
         "@types/react": "^17.0.9",
         "@types/react-dom": "^17.0.6",

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -6,12 +6,13 @@ try {
 } catch (e) {}
 
 // TODO: handle hosted/saas mode
-export const MODE = IS_DESKTOP_APP ? 'desktop' : 'demo';
+export const MODE = IS_DESKTOP_APP ? 'desktop' : 'browser';
 
 export const MODE_FEATURES = {
-  appHeader: MODE === 'demo',
-  connectors: MODE !== 'demo',
-  sql: MODE !== 'demo',
+  appHeader: MODE === 'browser',
+  connectors: MODE !== 'browser',
+  sql: MODE !== 'browser',
+  shareProject: MODE === 'browser',
 };
 
 export const DEBUG = true;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,4 +1,4 @@
-export const APP_NAME = 'datastation';
+export const APP_NAME = 'DataStation';
 
 let IS_DESKTOP_APP = false;
 try {

--- a/ui/HTTPPanel.tsx
+++ b/ui/HTTPPanel.tsx
@@ -14,7 +14,7 @@ import { Input } from './component-library/Input';
 import { Select } from './component-library/Select';
 
 export async function evalHTTPPanel(panel: HTTPPanelInfo) {
-  if (MODE === 'demo') {
+  if (MODE === 'browser') {
     const headers: { [v: string]: string } = {};
     panel.http.http.headers.forEach((h: { value: string; name: string }) => {
       headers[h.name] = h.value;

--- a/ui/ProjectStore.ts
+++ b/ui/ProjectStore.ts
@@ -64,7 +64,7 @@ export interface ProjectStore {
 export function makeStore(mode: string) {
   const state = {
     desktop: DesktopIPCStore,
-    demo: LocalStorageStore,
+    browser: LocalStorageStore,
     hosted: HostedStore,
   }[mode];
   return new state();

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -48,8 +48,14 @@ function getShareState(): undefined | ProjectState {
   const shareState = getQueryParameter('share');
   if (shareState) {
     // TODO: this can be more efficient than calling split
-    const intArray = Uint8Array.from(shareState.split(',').map(i => parseInt(i)));
-    console.log(intArray, shareState.split(','), parseInt(shareState.split(',')[3]));
+    const intArray = Uint8Array.from(
+      shareState.split(',').map((i) => parseInt(i))
+    );
+    console.log(
+      intArray,
+      shareState.split(','),
+      parseInt(shareState.split(',')[3])
+    );
     const uncompressed = JSON.parse(pako.inflate(intArray, { to: 'string' }));
     shareStateCache.state = rawStateToObjects(uncompressed);
   }
@@ -166,7 +172,11 @@ function App() {
                 Reset
               </Button>
               {MODE_FEATURES.shareProject && (
-                <div className="share" tabIndex="1000" onBlur={() => setShareDialog(false)}>
+                <div
+                  className="share"
+                  tabIndex="1000"
+                  onBlur={() => setShareDialog(false)}
+                >
                   <Button
                     onClick={() => {
                       computeShareURL();
@@ -176,9 +186,7 @@ function App() {
                     Share
                   </Button>
                   {shareDialog && (
-                    <div
-                      className="share-details"
-                    >
+                    <div className="share-details">
                       <p>
                         This is a URL encoding the entire state of the current
                         project. The URL and project data is not stored on any

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -174,7 +174,7 @@ function App() {
               {MODE_FEATURES.shareProject && (
                 <div
                   className="share"
-                  tabIndex="1000"
+                  tabIndex={1000}
                   onBlur={() => setShareDialog(false)}
                 >
                   <Button

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -166,7 +166,7 @@ function App() {
                 Reset
               </Button>
               {MODE_FEATURES.shareProject && (
-                <div className="share">
+                <div className="share" tabIndex="1000" onBlur={() => setShareDialog(false)}>
                   <Button
                     onClick={() => {
                       computeShareURL();
@@ -178,7 +178,6 @@ function App() {
                   {shareDialog && (
                     <div
                       className="share-details"
-                      onBlur={() => setShareDialog(false)}
                     >
                       <p>
                         This is a URL encoding the entire state of the current

--- a/ui/component-library/Input.tsx
+++ b/ui/component-library/Input.tsx
@@ -9,6 +9,7 @@ export function Input({
   max,
   label,
   disabled,
+  readOnly,
 }: {
   type?: 'text' | 'number' | 'email' | 'password';
   className?: string;
@@ -18,6 +19,7 @@ export function Input({
   max?: number;
   label?: string;
   disabled?: boolean;
+  readOnly?: boolean;
 }) {
   let inputClass = `input ${className ? ' ' + className : ''}`;
 
@@ -29,6 +31,7 @@ export function Input({
         onChange(e.target.value)
       }
       disabled={disabled}
+      readOnly={readOnly}
       value={value}
       min={min}
       max={max}

--- a/ui/style.css
+++ b/ui/style.css
@@ -17,7 +17,12 @@ header {
 header a {
   color: white;
   text-decoration: none;
-  padding-left: 15px;
+}
+
+header .button,
+header a {
+  margin-left: 15px;
+  display: inline-block;
 }
 
 .logo {
@@ -225,4 +230,25 @@ header {
 .alert-info {
   background: #ffe7e7;
   border: 1px solid #ffc0c0;
+}
+
+.share {
+  position: relative;
+}
+
+.share-details {
+  position: absolute;
+  top: 30px;
+  right: 1px;
+  background: white;
+  z-index: 1;
+  border: 1px solid #ccc;
+  padding: 15px;
+  width: 400px;
+  color: black;
+}
+
+.share-details input {
+  border: 1px solid;
+  width: 100%;
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -27,8 +27,6 @@ header a {
 
 .logo {
   padding-right: 15px;
-  font-weight: bolder;
-  font-size: 12px;
 }
 
 [contenteditable='true'] {

--- a/ui/style.css
+++ b/ui/style.css
@@ -27,7 +27,6 @@ header a {
 
 .logo {
   padding-right: 15px;
-  text-transform: uppercase;
   font-weight: bolder;
   font-size: 12px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.3.tgz#6d327abaa4be34a74e421ed6409a0ae2f47f4c3d"
   integrity sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==
 
+"@types/pako@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.1.tgz#33b237f3c9aff44d0f82fe63acffa4a365ef4a61"
+  integrity sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==
+
 "@types/papaparse@^5.2.5":
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.2.5.tgz#9d3cd9d932eb0dccda9e3f73f39996c4da3fa628"
@@ -550,6 +555,11 @@ packet-reader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
   integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
 
 papaparse@^5.3.1:
   version "5.3.1"


### PR DESCRIPTION
This uses pako to (zlib-style) compress the project state for use in a URL. This way we can serialize the entire project state as a URL that others can use. This is only enabled for the online environment and probably won't be enabled for the desktop version. We'll have to see about that.

Future problems:

* Sharing (large) file panels is going to be a problem (Chrome seems to have a limit of 2mb headers from a quick google search but it probably fails before then; Firefox and Safari seem to have lower limits)
* The serialized state includes `connectors` that contain username/password details. This doesn't matter for the online environment since it doesn't allow connectors (since they wouldn't work anyway). Just something to call out if things ever change in the future.
![image](https://user-images.githubusercontent.com/3925912/121822620-09ee1980-cc6e-11eb-9dcd-568e8e847d37.png)
