### PR TITLE
Support native program execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 electron/build
 yarn-error.log
 releases
+.results

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,3 @@
+DELETE THIS
+
+Panel results should be sync-ed to disk so they can be read from disk by the program panel.

--- a/desktop/app.ts
+++ b/desktop/app.ts
@@ -7,6 +7,7 @@ import { storeHandlers } from './store';
 import { registerRPCHandlers } from './rpc';
 import { evalSQLHandler } from './sql';
 import { evalHTTPHandler } from './http';
+import { programHandlers } from './program';
 
 app.whenReady().then(() => {
   const preload = path.join(__dirname, 'preload.js');
@@ -29,6 +30,7 @@ app.whenReady().then(() => {
     ...storeHandlers,
     evalSQLHandler,
     evalHTTPHandler,
+    ...programHandlers,
   ]);
 });
 

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -87,22 +87,28 @@ export const evalProgramHandler = {
         if (ppi.program.type === 'python') {
           const matcher = /, line ([1-9]*), in <module>/g;
           // Rewrite line numbers in traceback
-          e.message = e.message.replace(matcher, function (_, line) {
-            return `, line ${
-              line - PYTHON_PREAMBLE('').split('\n').length
-            }, in <module>`;
-          });
+          e.message = e.message.replace(
+            matcher,
+            function (_: string, line: string) {
+              return `, line ${
+                +line - PYTHON_PREAMBLE('').split('\n').length
+              }, in <module>`;
+            }
+          );
         } else if (ppi.program.type === 'javascript') {
           const matcher = RegExp(
             `${programTmp.path}:([1-9]*)`.replace('/', '\\/'),
             'g'
           );
           // Rewrite line numbers in traceback
-          e.message = e.message.replace(matcher, function (_, line) {
-            return `${
-              programTmp.path
-            }:${line - JAVASCRIPT_PREAMBLE('').split('\n').length}`;
-          });
+          e.message = e.message.replace(
+            matcher,
+            function (_: string, line: string) {
+              return `${programTmp.path}:${
+                +line - JAVASCRIPT_PREAMBLE('').split('\n').length
+              }`;
+            }
+          );
         }
 
         throw e;

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -1,0 +1,40 @@
+import fs from 'fs/promises';
+import util from 'util';
+import { exec } from 'child_process';
+
+import { file as makeTmpFile } from 'tmp-promise';
+
+import { ProgramPanelInfo } from '../shared/state';
+import { parseArrayBuffer } from '../shared/text';
+
+const execPromise = util.promisify(exec);
+
+export const evalProgramHandler = {
+  resource: 'evalProgram',
+  handler: async function (_: string, ppi: ProgramPanelInfo) {
+    const programTmp = await makeTmpFile();
+    const outputTmp = await makeTmpFile();
+
+    try {
+      const matcher = /DM_setPanel\(([a-Z-A-Z_\$0-9]+)\)/g;
+      const program = ppi.content.replace(
+        matcher,
+        function (match, panelResult) {
+          if (ppi.program.type === 'javascript') {
+            return `(() => { const fs = require('fs'); fs.writeFileSync('${outputTmp.path}', JSON.stringify(${match})) })()`;
+          } else {
+            return `with open('${outputTmp}', 'w') as f: import json; f.write(json.dumps(${match}))`;
+          }
+        }
+      );
+      await fs.writeFile(programTmp.path, program);
+      const runtime = ppi.program.type === 'javascript' ? 'node' : 'python3';
+      const { stdout } = await execPromise(`${runtime} ${programTmp.path}`);
+      const body = await fs.readFile(outputTmp.path);
+      return [await parseArrayBuffer('application/json', '', body), stdout];
+    } finally {
+      programTmp.cleanup();
+      outputTmp.cleanup();
+    }
+  },
+};

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -81,3 +81,5 @@ export const evalProgramHandler = {
     }
   },
 };
+
+export const programHandlers = [storeResultsHandler, evalProgramHandler];

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -4,7 +4,7 @@ import { exec } from 'child_process';
 
 import { file as makeTmpFile } from 'tmp-promise';
 
-import { ProgramPanelInfo, PanelResults } from '../shared/state';
+import { ProgramPanelInfo } from '../shared/state';
 import { parseArrayBuffer } from '../shared/text';
 
 const execPromise = util.promisify(exec);
@@ -13,13 +13,16 @@ let TMP_RESULTS_FILE = '.results';
 const JAVASCRIPT_PREAMBLE = (outFile: string) =>
   `
 const fs = require('fs');
-global.cache = {};
+global.cache = null;
 function DM_getPanel(i) {
-  if (global.cache[i]) {
+  if (global.cache) {
     return global.cache[i];
   }
  
-  global.cache[i] = JSON.parse(fs.readFileSync('${TMP_RESULTS_FILE}'));
+  global.cache = JSON.parse(fs.readFileSync('${TMP_RESULTS_FILE}'));
+  if (!global.cache) {
+    return [];
+  }
   return global.cache[i];
 }
 function DM_setPanel(v) {
@@ -30,11 +33,13 @@ function DM_setPanel(v) {
 
 const PYTHON_PREAMBLE = (outFile: string) => `
 import json as __DM_JSON
-__GLOBAL = {}
+__GLOBAL = None
 def DM_getPanel(i):
-  if i in __GLOBAL: return __GLOBAL[i]
+  global __GLOBAL
+  if __GLOBAL: return __GLOBAL[i]
   with open('${TMP_RESULTS_FILE}') as f:
-    __GLOBAL[i] = __DM_JSON.load(f)
+    __GLOBAL = __DM_JSON.load(f)
+  if not __GLOBAL: return []
   return __GLOBAL[i]
 def DM_setPanel(v):
   with open('${outFile}', 'w') as f:
@@ -47,7 +52,10 @@ const PREAMBLE = {
 
 export const storeResultsHandler = {
   resource: 'storeResults',
-  handler: function (_: string, results: PanelResults) {
+  handler: function (_: string, results: any) {
+    if (!results) {
+      return;
+    }
     return fs.writeFile(TMP_RESULTS_FILE, JSON.stringify(results));
   },
 };
@@ -66,14 +74,39 @@ export const evalProgramHandler = {
       const preamble = PREAMBLE[ppi.program.type](outputTmp.path);
       await fs.writeFile(programTmp.path, [preamble, ppi.content].join('\n'));
       const runtime = ppi.program.type === 'javascript' ? 'node' : 'python3';
-      const { stdout, stderr } = await execPromise(
-        `${runtime} ${programTmp.path}`
-      );
-      const body = await fs.readFile(outputTmp.path);
-      return [
-        await parseArrayBuffer('application/json', '', body),
-        stdout + stderr,
-      ];
+      try {
+        const { stdout, stderr } = await execPromise(
+          `${runtime} ${programTmp.path}`
+        );
+        const body = await fs.readFile(outputTmp.path);
+        return [
+          await parseArrayBuffer('application/json', '', body),
+          stdout + stderr,
+        ];
+      } catch (e) {
+        if (ppi.program.type === 'python') {
+          const matcher = /, line ([1-9]*), in <module>/g;
+          // Rewrite line numbers in traceback
+          e.message = e.message.replace(matcher, function (_, line) {
+            return `, line ${
+              line - PYTHON_PREAMBLE('').split('\n').length
+            }, in <module>`;
+          });
+        } else if (ppi.program.type === 'javascript') {
+          const matcher = RegExp(
+            `${programTmp.path}:([1-9]*)`.replace('/', '\\/'),
+            'g'
+          );
+          // Rewrite line numbers in traceback
+          e.message = e.message.replace(matcher, function (_, line) {
+            return `${
+              programTmp.path
+            }:${line - JAVASCRIPT_PREAMBLE('').split('\n').length}`;
+          });
+        }
+
+        throw e;
+      }
     } finally {
       programTmp.cleanup();
       outputTmp.cleanup();

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -63,7 +63,7 @@ export const evalProgramHandler = {
     const outputTmp = await makeTmpFile();
 
     try {
-      const preamble = PREAMBLE[ppi.program.type];
+      const preamble = PREAMBLE[ppi.program.type](outputTmp.path);
       await fs.writeFile(programTmp.path, [preamble, ppi.content].join('\n'));
       const runtime = ppi.program.type === 'javascript' ? 'node' : 'python3';
       const { stdout, stderr } = await execPromise(

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -63,7 +63,6 @@ export const evalProgramHandler = {
     const outputTmp = await makeTmpFile();
 
     try {
-      const matcher = /DM_setPanel\(([a-Z-A-Z_\$0-9]+)\)/g;
       const preamble = PREAMBLE[ppi.program.type];
       await fs.writeFile(programTmp.path, [preamble, ppi.content].join('\n'));
       const runtime = ppi.program.type === 'javascript' ? 'node' : 'python3';

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -38,7 +38,7 @@ def DM_getPanel(i):
   return __GLOBAL[i]
 def DM_setPanel(v):
   with open('${outFile}', 'w') as f:
-    json.dump(v, f)`;
+    __DM_JSON.dump(v, f)`;
 
 const PREAMBLE = {
   javascript: JAVASCRIPT_PREAMBLE,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -15,6 +15,7 @@ export const MODE_FEATURES = {
   shareProject: MODE === 'browser',
   corsOnly: MODE === 'browser',
   noBodyYOverflow: MODE !== 'browser',
+  storeResults: MODE !== 'browser',
 };
 
 export const DEBUG = true;

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -2,6 +2,16 @@ import * as uuid from 'uuid';
 
 import { mergeDeep } from './merge';
 
+export interface PanelResult {
+  exception?: string;
+  value?: Array<any>;
+  lastRun: Date;
+  loading: boolean;
+  stdout: string;
+}
+export type IDDict<T> = { [k: string]: T };
+export type PanelResults = IDDict<Array<PanelResult>>;
+
 export type ConnectorInfoType = 'sql' | 'http';
 
 export class ConnectorInfo {

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -10,7 +10,7 @@ export interface PanelResult {
   stdout: string;
 }
 export type IDDict<T> = { [k: string]: T };
-export type PanelResults = IDDict<Array<PanelResult>>;
+export type PanelResults = Array<Array<PanelResult>>;
 
 export type ConnectorInfoType = 'sql' | 'http';
 

--- a/type-overrides/lodash.d.ts
+++ b/type-overrides/lodash.d.ts
@@ -1,6 +1,6 @@
 declare module 'lodash.throttle' {
   declare function throttle<Input, Output>(
-    f: () => void,
+    f: (...args: Input) => Output,
     t: number
   ): (...args: Input) => Output;
   export = throttle;

--- a/ui/FieldPicker.tsx
+++ b/ui/FieldPicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PanelResult } from './ProjectStore';
+import { PanelResult } from '../shared/state';
 
 import { Input } from './component-library/Input';
 import { Select } from './component-library/Select';

--- a/ui/GraphPanel.tsx
+++ b/ui/GraphPanel.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import Chart from 'chart.js/auto';
 
-import { PanelInfo, GraphPanelInfo, GraphPanelInfoType } from '../shared/state';
+import {
+  PanelInfo,
+  GraphPanelInfo,
+  GraphPanelInfoType,
+  PanelResult,
+} from '../shared/state';
 
-import { PanelResult } from './ProjectStore';
 import { PanelSourcePicker } from './PanelSourcePicker';
 import { FieldPicker } from './FieldPicker';
 import { Select } from './component-library/Select';

--- a/ui/Page.tsx
+++ b/ui/Page.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
-import { ConnectorInfo, ProjectPage } from '../shared/state';
+import { ConnectorInfo, ProjectPage, PanelResult } from '../shared/state';
 
 import { Panels } from './Panels';
 import { evalPanel } from './Panel';
-import { PanelResult } from './ProjectStore';
 
 export function Page({
   page,
@@ -20,11 +19,12 @@ export function Page({
   setPanelResults: (panelIndex: number, results: PanelResult) => void;
 }) {
   async function reevalPanel(panelIndex: number, reset?: boolean) {
+    const panel = panelResults[panelIndex];
+    panel.lastRun = null;
+    panel.loading = true;
     if (reset) {
-      setPanelResults(panelIndex, {
-        ...panelResults[panelIndex],
-        lastRun: null,
-      });
+      panel.loading = false;
+      setPanelResults(panelIndex, panel);
       return;
     }
 
@@ -35,9 +35,15 @@ export function Page({
         panelResults,
         connectors
       );
-      setPanelResults(panelIndex, { lastRun: new Date(), value: r, stdout });
+      setPanelResults(panelIndex, {
+        lastRun: new Date(),
+        value: r,
+        stdout,
+        loading: false,
+      });
     } catch (e) {
       setPanelResults(panelIndex, {
+        loading: false,
         lastRun: new Date(),
         exception: e.stack,
         stdout: '',

--- a/ui/Page.tsx
+++ b/ui/Page.tsx
@@ -20,8 +20,11 @@ export function Page({
 }) {
   async function reevalPanel(panelIndex: number, reset?: boolean) {
     const panel = panelResults[panelIndex];
-    panel.lastRun = null;
-    panel.loading = true;
+    if (panel) {
+      panel.lastRun = null;
+      panel.loading = true;
+    }
+
     if (reset) {
       panel.loading = false;
       setPanelResults(panelIndex, panel);

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -12,10 +12,10 @@ import {
   TablePanelInfo,
   LiteralPanelInfo,
   FilePanelInfo,
+  PanelResult,
 } from '../shared/state';
 import { MODE_FEATURES } from '../shared/constants';
 
-import { PanelResult } from './ProjectStore';
 import { GraphPanel, GraphPanelDetails } from './GraphPanel';
 import { evalHTTPPanel, HTTPPanelDetails } from './HTTPPanel';
 import { evalFilePanel, FilePanelDetails } from './FilePanel';
@@ -129,6 +129,7 @@ export function Panel({
     exception: null,
     lastRun: null,
     stdout: '',
+    loading: false,
   };
   React.useEffect(() => {
     if (!results.value) {
@@ -214,7 +215,9 @@ export function Panel({
           )}
           <span className="panel-controls vertical-align-center flex-right">
             <span className="last-run">
-              {results.lastRun
+              {results.loading
+                ? 'Loading'
+                : results.lastRun
                 ? 'Last run ' + results.lastRun
                 : 'Run to apply changes'}
             </span>

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -358,7 +358,7 @@ export function Panel({
                 />
               )}
               {exception && (
-                <div className="error">
+                <div className="alert alert-error">
                   <div>Error evaluating panel:</div>
                   <pre>
                     <code>{exception}</code>

--- a/ui/Panels.tsx
+++ b/ui/Panels.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
-import { ProjectPage, PanelInfo, LiteralPanelInfo } from '../shared/state';
+import {
+  ProjectPage,
+  PanelInfo,
+  LiteralPanelInfo,
+  PanelResult,
+} from '../shared/state';
 
-import { PanelResult } from './ProjectStore';
 import { Panel } from './Panel';
 import { Button } from './component-library/Button';
 

--- a/ui/ProgramPanel.tsx
+++ b/ui/ProgramPanel.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import circularSafeStringify from 'json-stringify-safe';
 
+import { MODE } from '../shared/constants';
 import { ProgramPanelInfo } from '../shared/state';
 
+import { asyncRPC } from './asyncRPC';
 import { PanelResult } from './ProjectStore';
 import { Select } from './component-library/Select';
 
@@ -12,6 +14,26 @@ export function evalProgramPanel(
 ): Promise<[any, string]> {
   const program = panel.program;
   const anyWindow = window as any;
+
+  if (MODE === 'desktop') {
+    // TODO: make panel substitution based on an actual parser since
+    // regex will match instances of `' foo bar DM_getPanel(21)[sdklf] '`
+    // among other bad things...
+    const matcher = /DM_getPanel\(([0-9]+)\)/g;
+    const content = panel.content.replace(matcher, function (match, panelIndex) {
+      replacements.push(+panelIndex);
+      return `t${replacements.length - 1}`;
+    });
+
+    return asyncRPC<ProgramPanelInfo, null, [Array<object>, string]>(
+      'evalProgram',
+      null,
+      {
+        ...panel,
+        content,
+      },
+    );
+  }
 
   // TODO: better deep copy
   anyWindow.DM_getPanel = (panelId: number) =>

--- a/ui/ProgramPanel.tsx
+++ b/ui/ProgramPanel.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import circularSafeStringify from 'json-stringify-safe';
 
 import { MODE } from '../shared/constants';
-import { ProgramPanelInfo } from '../shared/state';
+import { PanelResult, ProgramPanelInfo } from '../shared/state';
 
 import { asyncRPC } from './asyncRPC';
-import { PanelResult } from './ProjectStore';
 import { Select } from './component-library/Select';
 
 export function evalProgramPanel(
@@ -16,22 +15,10 @@ export function evalProgramPanel(
   const anyWindow = window as any;
 
   if (MODE === 'desktop') {
-    // TODO: make panel substitution based on an actual parser since
-    // regex will match instances of `' foo bar DM_getPanel(21)[sdklf] '`
-    // among other bad things...
-    const matcher = /DM_getPanel\(([0-9]+)\)/g;
-    const content = panel.content.replace(matcher, function (match, panelIndex) {
-      replacements.push(+panelIndex);
-      return `t${replacements.length - 1}`;
-    });
-
     return asyncRPC<ProgramPanelInfo, null, [Array<object>, string]>(
       'evalProgram',
       null,
-      {
-        ...panel,
-        content,
-      },
+      panel
     );
   }
 

--- a/ui/ProjectStore.ts
+++ b/ui/ProjectStore.ts
@@ -2,16 +2,9 @@ import { IpcRenderer } from 'electron';
 import throttle from 'lodash.throttle';
 import * as React from 'react';
 
-import { ProjectState, DEFAULT_PROJECT } from '../shared/state';
+import { ProjectState, DEFAULT_PROJECT, PanelResult } from '../shared/state';
 
 import { asyncRPC } from './asyncRPC';
-
-export interface PanelResult {
-  exception?: string;
-  value?: Array<any>;
-  lastRun: Date;
-  stdout: string;
-}
 
 class LocalStorageStore {
   makeKey(projectId: string) {
@@ -48,16 +41,6 @@ class DesktopIPCStore {
   }
 }
 
-class HostedStore {
-  async update(projectId: string, state: ProjectState) {
-    throw new Error('Unsupported state manager');
-  }
-
-  async get(): Promise<ProjectState> {
-    throw new Error('Unsupported state manager');
-  }
-}
-
 export interface ProjectStore {
   update: (projectId: string, state: ProjectState) => Promise<void>;
   get: (projectId: string) => Promise<ProjectState>;
@@ -67,7 +50,6 @@ export function makeStore(mode: string, syncMillis: number = 5000) {
   const storeClass = {
     desktop: DesktopIPCStore,
     browser: LocalStorageStore,
-    hosted: HostedStore,
   }[mode];
   const store = new storeClass();
   if (syncMillis) {

--- a/ui/SQLPanel.tsx
+++ b/ui/SQLPanel.tsx
@@ -5,11 +5,12 @@ import {
   SQLConnectorInfo,
   SQLConnectorInfoType,
   SQLPanelInfo,
+  PanelResult,
 } from '../shared/state';
 import { DEBUG, MODE_FEATURES } from '../shared/constants';
 
 import { asyncRPC } from './asyncRPC';
-import { PanelResult, ProjectContext } from './ProjectStore';
+import { ProjectContext } from './ProjectStore';
 import { Select } from './component-library/Select';
 
 export async function evalSQLPanel(

--- a/ui/TablePanel.tsx
+++ b/ui/TablePanel.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 
-import { PanelInfo, TablePanelInfo, TableColumn } from '../shared/state';
+import {
+  PanelInfo,
+  TablePanelInfo,
+  TableColumn,
+  PanelResult,
+} from '../shared/state';
 
 import { PanelSourcePicker } from './PanelSourcePicker';
-import { PanelResult } from './ProjectStore';
 import { Button } from './component-library/Button';
 import { FieldPicker } from './FieldPicker';
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -359,9 +359,14 @@ header > div {
   padding: 15px 5px;
 }
 
-.alert-info {
+.alert-error {
   background: #ffe7e7;
   border: 1px solid #ffc0c0;
+}
+
+.alert-info {
+  background: #e7f7ff;
+  border: 1px solid #c0f0ff;
 }
 
 .share {


### PR DESCRIPTION
## For desktop builds

* All program code is proxied to a child running real Python/Node on your desktop
* This means that Python/Node is a requirement for running these scripts
* FINALLY meaningful stacktraces
* DM_setPanel/DM_getPanel are implemented as builtins prepended to your execution script that read/write from files on disk
* Results are written to a file on disk on execution (only when running desktop builds)

## Potential problems this introduces

* This doesn't check to make sure Python/Node is available on your machine
* This reintroduces a bug where when you move a panel, its results don't follow you
* The temporary file doesn't exist after execution so it can be annoying to debug...

## Screenshot

![image](https://user-images.githubusercontent.com/3925912/123683382-22d3fe80-d81a-11eb-8df0-4edd5bbef8b4.png)
