### PR TITLE
Add support for exporting panel

### DIFF
--- a/ui/GraphPanel.tsx
+++ b/ui/GraphPanel.tsx
@@ -90,6 +90,20 @@ export function GraphPanel({
 
     const ctx = ref.current.getContext('2d');
     const chart = new Chart(ctx, {
+      plugins: [
+        {
+          // Pretty ridiculous there's no builtin way to set a background color
+          // https://stackoverflow.com/a/38493678/1507139
+          beforeDraw: function () {
+            const chartArea = chart.chartArea;
+
+            ctx.save();
+            ctx.fillStyle = 'white';
+            ctx.fillRect(0, 0, ref.current.width, ref.current.height);
+            ctx.restore();
+          },
+        },
+      ],
       type: panel.graph.type,
       data: {
         labels: value.map((d) => d[panel.graph.x]),

--- a/ui/style.css
+++ b/ui/style.css
@@ -424,3 +424,7 @@ header > div {
   color: #aaa;
   margin-bottom: 30px;
 }
+
+canvas {
+  background: white;
+}


### PR DESCRIPTION
Allows downloading graphs as PNG; tries to download everything else as CSV if possible, falling back to JSON, and then ultimately falling back to .txt.

<img width="588" alt="Screen Shot 2021-06-28 at 4 00 12 PM" src="https://user-images.githubusercontent.com/3925912/123696662-f88a3d00-d829-11eb-9387-0d477d7708dd.png">
<img width="706" alt="Screen Shot 2021-06-28 at 4 00 17 PM" src="https://user-images.githubusercontent.com/3925912/123696663-f922d380-d829-11eb-943e-cbd6a415737f.png">
