### PR TITLE
Support project files

### DIFF
--- a/desktop/app.ts
+++ b/desktop/app.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 
 import { app, BrowserWindow, ipcMain } from 'electron';
 
@@ -8,6 +8,8 @@ import { registerRPCHandlers } from './rpc';
 import { evalSQLHandler } from './sql';
 import { evalHTTPHandler } from './http';
 import { evalProgramHandler } from './program';
+
+const project = process.argv[1];
 
 app.whenReady().then(() => {
   const preload = path.join(__dirname, 'preload.js');
@@ -24,7 +26,7 @@ app.whenReady().then(() => {
     // In addition to removing the menu on Windows/Linux this also disables Chrome devtools.
     win.removeMenu();
   }
-  win.loadFile(path.join(__dirname, 'index.html'));
+  win.loadFile(path.join(__dirname, 'index.html?project=' + project));
 
   registerRPCHandlers(ipcMain, [
     ...storeHandlers,

--- a/desktop/app.ts
+++ b/desktop/app.ts
@@ -1,16 +1,102 @@
 import path from 'path';
 import { spawn } from 'child_process';
 
-import { app, BrowserWindow, Menu, ipcMain, dialog, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  MenuItemConstructorOptions,
+  ipcMain,
+  dialog,
+  shell,
+} from 'electron';
 
-import { APP_NAME, DEBUG, DISK_ROOT } from '../shared/constants';
+import { APP_NAME, DEBUG } from '../shared/constants';
+
+import { DISK_ROOT, PROJECT_EXTENSION } from './constants';
 import { storeHandlers, ensureFile } from './store';
 import { registerRPCHandlers } from './rpc';
 import { evalSQLHandler } from './sql';
 import { evalHTTPHandler } from './http';
 import { evalProgramHandler } from './program';
 
-const project = process.argv[1];
+const dsprojFlag = '--dsproj';
+
+async function openProject() {
+  const { filePaths } = await dialog.showOpenDialog({
+    properties: ['openFile'],
+    defaultPath: DISK_ROOT,
+    filters: [
+      {
+        name: 'DataStation Projects',
+        extensions: [PROJECT_EXTENSION],
+      },
+    ],
+  });
+  if (filePaths.length) {
+    let cmd = process.argv[0];
+    let args = [dsprojFlag, filePaths[0]];
+    if (cmd.toLowerCase().endsWith('electron')) {
+      cmd = 'yarn';
+      args = ['start-desktop', ...args];
+    }
+    console.log(`Spawning: "${cmd} ${args.join(' ')}"`);
+    spawn(cmd, args);
+  }
+}
+
+const menuTemplate = [
+  ...(process.platform === 'darwin'
+    ? [
+        {
+          label: APP_NAME,
+          submenu: [{ role: 'quit' }],
+        },
+      ]
+    : []),
+  {
+    label: 'File',
+    submenu: [
+      {
+        label: 'Open Project',
+        click: openProject,
+      },
+    ],
+  },
+  {
+    label: 'Help',
+    role: 'help',
+    submenu: [
+      {
+        label: 'Documentation',
+        click: () =>
+          shell.openExternal('https://datastation.multiprocess.io/docs/'),
+      },
+      {
+        label: 'Community',
+        click: () => shell.openExternal('https://discord.gg/f2wQBc4bXX'),
+      },
+    ],
+  },
+  ...(DEBUG
+    ? [
+        {
+          label: 'View',
+          submenu: [
+            { role: 'reload' },
+            { role: 'forceReload' },
+            { role: 'toggleDevTools' },
+            { type: 'separator' },
+            { role: 'resetZoom' },
+            { role: 'zoomIn' },
+            { role: 'zoomOut' },
+            { type: 'separator' },
+            { role: 'togglefullscreen' },
+          ],
+        },
+      ]
+    : []),
+];
 
 app.whenReady().then(async () => {
   const preload = path.join(__dirname, 'preload.js');
@@ -24,55 +110,35 @@ app.whenReady().then(async () => {
     },
   });
 
+  let project = '';
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === dsprojFlag) {
+      project = process.argv[i + 1];
+      break;
+    }
+  }
+
   // Make sure this file/path exists
   await ensureFile('.settings');
 
-  const menu = Menu.buildFromTemplate([
-    {
-      label: 'File',
-      submenu: [
-        {
-          label: 'Open Project',
-          click: async () => {
-            const { filePaths } = await dialog.showOpenDialog({
-              properties: ['openFile'],
-              defaultPath: DISK_ROOT,
-              filters: [
-                { name: 'DataStation Projects', extensions: ['.dsproj'] },
-              ],
-            });
-            if (filePaths.length) {
-              spawn(process.argv[0], filePaths);
-            }
-          },
-        },
-      ],
-    },
-    {
-      label: 'Help',
-      role: 'help',
-      submenu: [
-        {
-          label: 'Documentation',
-          click: () =>
-            shell.openExternal('https://datastation.multiprocess.io/docs/'),
-        },
-        {
-          label: 'Community',
-          click: () => shell.openExternal('https://discord.gg/f2wQBc4bXX'),
-        },
-      ],
-    },
-  ]);
+  const menu = Menu.buildFromTemplate(
+    menuTemplate as MenuItemConstructorOptions[]
+  );
   Menu.setApplicationMenu(menu);
 
-  win.loadFile(path.join(__dirname, 'index.html?project=' + project));
+  win.loadURL(
+    'file://' + path.join(__dirname, 'index.html?project=' + project)
+  );
 
   registerRPCHandlers(ipcMain, [
     ...storeHandlers,
     evalSQLHandler,
     evalHTTPHandler,
     evalProgramHandler,
+    {
+      resource: 'openProject',
+      handler: (_1: string, _2: any) => openProject(),
+    },
   ]);
 });
 

--- a/desktop/constants.ts
+++ b/desktop/constants.ts
@@ -1,0 +1,7 @@
+import os from 'os';
+import path from 'path';
+
+export const DISK_ROOT = path.join(os.homedir(), 'DataStationProjects');
+
+export const PROJECT_EXTENSION = 'dsproj';
+export const RESULTS_FILE = '.results';

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -5,13 +5,12 @@ import util from 'util';
 
 import { file as makeTmpFile } from 'tmp-promise';
 
-import { DISK_ROOT } from '../shared/constants';
+import { DISK_ROOT, RESULTS_FILE } from '../shared/constants';
 import { ProgramPanelInfo } from '../shared/state';
 import { parseArrayBuffer } from '../shared/text';
 
 const execPromise = util.promisify(exec);
 
-let TMP_RESULTS_FILE = path.join(DISK_ROOT, '.results');
 const JAVASCRIPT_PREAMBLE = (outFile: string) =>
   `
 const fs = require('fs');
@@ -21,7 +20,7 @@ function DM_getPanel(i) {
     return global.cache[i];
   }
  
-  global.cache = JSON.parse(fs.readFileSync('${TMP_RESULTS_FILE}'));
+  global.cache = JSON.parse(fs.readFileSync('${RESULTS_FILE}'));
   if (!global.cache) {
     return [];
   }
@@ -39,7 +38,7 @@ __GLOBAL = None
 def DM_getPanel(i):
   global __GLOBAL
   if __GLOBAL: return __GLOBAL[i]
-  with open('${TMP_RESULTS_FILE}') as f:
+  with open('${RESULTS_FILE}') as f:
     __GLOBAL = __DM_JSON.load(f)
   if not __GLOBAL: return []
   return __GLOBAL[i]
@@ -55,10 +54,6 @@ const PREAMBLE = {
 export const evalProgramHandler = {
   resource: 'evalProgram',
   handler: async function (_: string, ppi: ProgramPanelInfo) {
-    if (!TMP_RESULTS_FILE) {
-      return [];
-    }
-
     const programTmp = await makeTmpFile();
     const outputTmp = await makeTmpFile();
 

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -5,9 +5,10 @@ import util from 'util';
 
 import { file as makeTmpFile } from 'tmp-promise';
 
-import { DISK_ROOT, RESULTS_FILE } from '../shared/constants';
 import { ProgramPanelInfo } from '../shared/state';
 import { parseArrayBuffer } from '../shared/text';
+
+import { DISK_ROOT, RESULTS_FILE } from './constants';
 
 const execPromise = util.promisify(exec);
 

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -2,13 +2,17 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { ProjectState } from '../shared/state';
-import { DISK_ROOT } from '../shared/constants';
+import {
+  DISK_ROOT,
+  PROJECT_EXTENSION,
+  RESULTS_FILE,
+} from '../shared/constants';
 
 export const storeHandlers = [
   {
     resource: 'getProjectState',
     handler: async (projectId: string) => {
-      const fileName = await ensureFile(projectId + '.project');
+      const fileName = await ensureFile(projectId + PROJECT_EXTENSION);
       const f = await fs.readFile(fileName);
       return JSON.parse(f.toString());
     },
@@ -16,7 +20,7 @@ export const storeHandlers = [
   {
     resource: 'updateProjectState',
     handler: async (projectId: string, newState: ProjectState) => {
-      const fileName = await ensureFile(projectId + '.project');
+      const fileName = await ensureFile(projectId + PROJECT_EXTENSION);
       return fs.writeFile(fileName, JSON.stringify(newState));
     },
   },
@@ -26,7 +30,7 @@ export const storeHandlers = [
       if (!results) {
         return;
       }
-      const fileName = await ensureFile('.results');
+      const fileName = await ensureFile(RESULTS_FILE);
       return fs.writeFile(fileName, JSON.stringify(results));
     },
   },

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -36,7 +36,7 @@ export const storeHandlers = [
   },
 ];
 
-async function ensureFile(f: string) {
+export async function ensureFile(f: string) {
   await fs.mkdir(DISK_ROOT, { recursive: true });
   return path.join(DISK_ROOT, f);
 }

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -40,11 +40,11 @@ export const storeHandlers = [
 
 export function ensureProjectFile(projectId: string) {
   const ext = projectId.split('.').pop();
-  if (projectId.endsWith(ext)) {
+  if (ext !== projectId && ext && projectId.endsWith(ext)) {
     return ensureFile(projectId);
   }
 
-  return ensureFile('.' + PROJECT_EXTENSION);
+  return ensureFile(projectId + '.' + PROJECT_EXTENSION);
 }
 
 export async function ensureFile(f: string) {

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -2,25 +2,27 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { ProjectState } from '../shared/state';
-import {
-  DISK_ROOT,
-  PROJECT_EXTENSION,
-  RESULTS_FILE,
-} from '../shared/constants';
+
+import { DISK_ROOT, PROJECT_EXTENSION, RESULTS_FILE } from './constants';
 
 export const storeHandlers = [
   {
     resource: 'getProjectState',
     handler: async (projectId: string) => {
-      const fileName = await ensureFile(projectId + PROJECT_EXTENSION);
-      const f = await fs.readFile(fileName);
-      return JSON.parse(f.toString());
+      const fileName = await ensureProjectFile(projectId);
+      try {
+        const f = await fs.readFile(fileName);
+        return JSON.parse(f.toString());
+      } catch (e) {
+        console.error(e);
+        return null;
+      }
     },
   },
   {
     resource: 'updateProjectState',
     handler: async (projectId: string, newState: ProjectState) => {
-      const fileName = await ensureFile(projectId + PROJECT_EXTENSION);
+      const fileName = await ensureProjectFile(projectId);
       return fs.writeFile(fileName, JSON.stringify(newState));
     },
   },
@@ -36,7 +38,19 @@ export const storeHandlers = [
   },
 ];
 
+export function ensureProjectFile(projectId: string) {
+  const ext = projectId.split('.').pop();
+  if (projectId.endsWith(ext)) {
+    return ensureFile(projectId);
+  }
+
+  return ensureFile('.' + PROJECT_EXTENSION);
+}
+
 export async function ensureFile(f: string) {
+  if (path.isAbsolute(f)) {
+    return f;
+  }
   await fs.mkdir(DISK_ROOT, { recursive: true });
   return path.join(DISK_ROOT, f);
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -19,6 +19,7 @@ export const MODE_FEATURES = {
   corsOnly: MODE === 'browser',
   noBodyYOverflow: MODE !== 'browser',
   storeResults: MODE !== 'browser',
+  useDefaultProject: MODE === 'browser',
 };
 
 export const RPC_ASYNC_REQUEST = 'rpcAsyncRequest';
@@ -43,5 +44,5 @@ function getConfig<T>(v: string, _default: T) {
   return _default;
 }
 
-export const DEBUG = getConfig<Boolean>('DEBUG', true);
+export const DEBUG = getConfig<boolean>('DEBUG', true);
 export const VERSION = getConfig<string>('VERSION', 'development');

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,6 +1,3 @@
-import os from 'os';
-import path from 'path';
-
 export const APP_NAME = 'DataStation Community Edition';
 
 let IS_DESKTOP_APP = false;
@@ -24,10 +21,6 @@ export const MODE_FEATURES = {
 
 export const RPC_ASYNC_REQUEST = 'rpcAsyncRequest';
 export const RPC_ASYNC_RESPONSE = 'rpcAsyncResponse';
-
-export const DISK_ROOT = path.join(os.homedir(), '.datastation');
-export const PROJECT_EXTENSION = '.dsproj';
-export const RESULTS_FILE = '.results';
 
 function getConfig<T>(v: string, _default: T) {
   const key = 'DS_CONFIG_' + v;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -25,6 +25,8 @@ export const RPC_ASYNC_REQUEST = 'rpcAsyncRequest';
 export const RPC_ASYNC_RESPONSE = 'rpcAsyncResponse';
 
 export const DISK_ROOT = path.join(os.homedir(), '.datastation');
+export const PROJECT_EXTENSION = '.dsproj';
+export const RESULTS_FILE = '.results';
 
 function getConfig<T>(v: string, _default: T) {
   const key = 'DS_CONFIG_' + v;

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -1,6 +1,7 @@
 import * as uuid from 'uuid';
 
 import { mergeDeep } from './merge';
+import { VERSION } from './constants';
 
 export interface PanelResult {
   exception?: string;
@@ -259,15 +260,21 @@ export class ProjectState {
   projectName: string;
   connectors: Array<ConnectorInfo>;
   id: string;
+  originalVersion: string;
+  lastVersion: string;
 
   constructor(
     projectName?: string,
     pages?: Array<ProjectPage>,
-    connectors?: Array<ConnectorInfo>
+    connectors?: Array<ConnectorInfo>,
+    originalVersion?: string,
+    lastVersion?: string
   ) {
     this.pages = pages || [];
     this.projectName = projectName || '';
     this.connectors = connectors || [];
+    this.originalVersion = originalVersion || VERSION;
+    this.lastVersion = lastVersion || VERSION;
     this.id = uuid.v4();
   }
 }

--- a/ui/Pages.tsx
+++ b/ui/Pages.tsx
@@ -46,11 +46,6 @@ export function Pages({
     setPanelResultsByPageInternal(results);
   }
 
-  // Reset all page results when project changes
-  React.useEffect(() => {
-    setPanelResultsByPage({});
-  }, [state.id]);
-
   // Make sure panelResults are initialized when page changes.
   React.useEffect(() => {
     if (page && !panelResultsByPage[page.id]) {

--- a/ui/ProjectStore.ts
+++ b/ui/ProjectStore.ts
@@ -46,7 +46,7 @@ export interface ProjectStore {
   get: (projectId: string) => Promise<ProjectState>;
 }
 
-export function makeStore(mode: string, syncMillis: number = 5000) {
+export function makeStore(mode: string, syncMillis: number = 2000) {
   const storeClass = {
     desktop: DesktopIPCStore,
     browser: LocalStorageStore,

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -100,10 +100,9 @@ function useProjectState(
 }
 
 function App() {
-  // TODO: projectId needs to come from opened project.
   const shareState = getShareState();
   const [projectId, setProjectId] = React.useState(
-    (shareState && shareState.id) || 'default'
+    (shareState && shareState.id) || getQueryParameter('project') || 'default'
   );
 
   const store = makeStore(MODE);
@@ -130,6 +129,7 @@ function App() {
 
   // Set body overflow once on init
   React.useEffect(() => {
+    document.title = state.projectName;
     if (MODE_FEATURES.noBodyYOverflow) {
       document.body.style.overflowY = 'hidden';
     }

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -121,8 +121,8 @@ function App() {
   const shareState = getShareState();
   const [projectId, setProjectId] = React.useState(
     (shareState && shareState.id) ||
-    getQueryParameter('project') ||
-    (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
+      getQueryParameter('project') ||
+      (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
 
   const store = makeStore(MODE);
@@ -231,7 +231,7 @@ function App() {
                         If you make changes, you will need to click "Share"
                         again to get a new URL.
                       </p>
-                      <Input readOnly value={shareURL} onChange={() => { }} />
+                      <Input readOnly value={shareURL} onChange={() => {}} />
                       <p>
                         <a href="https://tinyurl.com/app">TinyURL</a> is a good
                         service for shortening these URLs correctly, some other

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -121,8 +121,8 @@ function App() {
   const shareState = getShareState();
   const [projectId, setProjectId] = React.useState(
     (shareState && shareState.id) ||
-      getQueryParameter('project') ||
-      (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
+    getQueryParameter('project') ||
+    (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
 
   const store = makeStore(MODE);
@@ -231,7 +231,7 @@ function App() {
                         If you make changes, you will need to click "Share"
                         again to get a new URL.
                       </p>
-                      <Input readOnly value={shareURL} onChange={() => {}} />
+                      <Input readOnly value={shareURL} onChange={() => { }} />
                       <p>
                         <a href="https://tinyurl.com/app">TinyURL</a> is a good
                         service for shortening these URLs correctly, some other
@@ -290,7 +290,7 @@ function App() {
                     disabled={!projectNameTmp}
                     onClick={() => setProjectId(projectNameTmp)}
                   >
-                    Save
+                    {projectNameTmp ? 'Go!' : 'Waiting for a name...'}
                   </Button>
                 </div>
                 <div className="project-existing">

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -75,6 +75,10 @@ function useProjectState(
     setProjectState(newState);
   }
 
+  const isDefault =
+    MODE_FEATURES.useDefaultProject &&
+    projectId === DEFAULT_PROJECT.projectName;
+
   // Re-read state when projectId changes
   React.useEffect(() => {
     if (shareState) {
@@ -86,15 +90,13 @@ function useProjectState(
       let state;
       try {
         let rawState = await store.get(projectId);
-        console.log(rawState);
-        if (!rawState && !isNewProject) {
+        if (!rawState && (!isNewProject || isDefault)) {
           throw new Error();
         } else {
           state = rawStateToObjects(rawState);
         }
-        console.log(state);
       } catch (e) {
-        if (MODE_FEATURES.useDefaultProject && projectId === 'default') {
+        if (isDefault) {
           state = DEFAULT_PROJECT;
         } else {
           console.error(e);
@@ -120,7 +122,7 @@ function App() {
   const [projectId, setProjectId] = React.useState(
     (shareState && shareState.id) ||
       getQueryParameter('project') ||
-      (MODE_FEATURES.useDefaultProject ? 'default' : '')
+      (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
 
   const store = makeStore(MODE);
@@ -285,6 +287,7 @@ function App() {
                 <div className="form-row">
                   <Button
                     type="primary"
+                    disabled={!projectNameTmp}
                     onClick={() => setProjectId(projectNameTmp)}
                   >
                     Save

--- a/ui/component-library/Modal.tsx
+++ b/ui/component-library/Modal.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export function Modal({
+  open,
+  children,
+}: {
+  open: boolean;
+  children: React.ReactNode;
+}) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="modal">
+      <div className="modal-body">{children}</div>
+    </div>
+  );
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -444,3 +444,24 @@ canvas {
   border: 1px solid #ccc;
   padding: 15px;
 }
+
+.project-name {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 15px;
+  margin: 15px auto;
+  width: 500px;
+}
+
+.project-name .input,
+.project-name .input input,
+.project-name .button {
+  width: 100%;
+  padding: 15px;
+}
+
+.project-existing {
+  border-top: 1px solid #ccc;
+  padding-top: 15px;
+  margin-top: 15px;
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -154,12 +154,22 @@ label.select select {
   padding: 0;
 }
 
+.button:not(.material-icons):disabled,
+.button:not(.material-icons):disabled:hover {
+  background: #ccc;
+  color: #777;
+  cursor: not-allowed;
+  pointer-events: all !important;
+}
+
 .button.button--primary.material-icons {
   color: #9f04ff;
 }
 
 .button.material-icons:disabled,
 .button.material-icons:disabled:hover {
+  cursor: not-allowed;
+  pointer-events: all !important;
   color: #ccc;
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -428,3 +428,19 @@ header > div {
 canvas {
   background: white;
 }
+
+.modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.modal-body {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 15px;
+}


### PR DESCRIPTION
Adds support for saving project files and loading from them. This logic still won't be able to do 'Open With' on any OS since it depends on the --dsproj flag to know what the project is.

![image](https://user-images.githubusercontent.com/3925912/123869825-82580a00-d8ff-11eb-9f15-11916febcc9a.png)

