### PR TITLE
Fix support for parquet, simplify import of excel files, improve feedback on panel evaluation

### DIFF
--- a/desktop/file.ts
+++ b/desktop/file.ts
@@ -17,7 +17,7 @@ export const evalFileHandler = {
   ) {
     if (!server) {
       const body = await fs.readFile(resolvePath(name));
-      return parseArrayBuffer('text/plain', name, body, additionalParsers);
+      return parseArrayBuffer('', name, body, additionalParsers);
     }
 
     const config = await getSSHConfig(server);
@@ -25,6 +25,6 @@ export const evalFileHandler = {
     const sftp = new Client();
     await sftp.connect(config);
     let body = (await sftp.get(name)) as ArrayBuffer;
-    return await parseArrayBuffer('text/plain', name, body, additionalParsers);
+    return await parseArrayBuffer('', name, body, additionalParsers);
   },
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "ace-builds": "^1.4.12",
     "chart.js": "^3.3.2",
+    "date-fns": "^2.22.1",
     "json-stringify-safe": "^5.0.1",
     "mysql2": "^2.2.5",
     "node-fetch": "^2.6.1",

--- a/ui/FilePanel.tsx
+++ b/ui/FilePanel.tsx
@@ -16,11 +16,7 @@ export async function evalFilePanel(
   servers: Array<ServerInfo>
 ) {
   if (MODE === 'browser') {
-    return await parseArrayBuffer(
-      'text/plain',
-      panel.file.name,
-      panel.file.content
-    );
+    return await parseArrayBuffer('', panel.file.name, panel.file.content);
   }
 
   return await asyncRPC<Proxy<{ name: string }>, string, Array<object>>(
@@ -28,12 +24,6 @@ export async function evalFilePanel(
     panel.content,
     { ...panel.file, server: servers.find((s) => s.id === panel.serverId) }
   );
-}
-
-// This is kind of duplicated
-const SUPPORTED_FILE_TYPES = ['csv', 'json', 'xlsx'];
-if (MODE !== 'browser') {
-  SUPPORTED_FILE_TYPES.push('parquet');
 }
 
 export function FilePanelDetails({
@@ -49,7 +39,6 @@ export function FilePanelDetails({
       <div className="form-row">
         <FileInput
           label="File"
-          accept={SUPPORTED_FILE_TYPES.map((p: string) => `.${p}`).join(',')}
           value={panel.file.name}
           allowManualEntry={MODE !== 'browser' ? true : false}
           allowFilePicker={!panel.serverId ? true : false}

--- a/ui/LiteralPanel.tsx
+++ b/ui/LiteralPanel.tsx
@@ -7,7 +7,7 @@ import { Select } from './component-library/Select';
 export async function evalLiteralPanel(panel: LiteralPanelInfo) {
   const literal = panel.literal;
   const array = new TextEncoder().encode(panel.content);
-  return await parseArrayBuffer('text/plain', 'literal.' + literal.type, array);
+  return await parseArrayBuffer('', 'literal.' + literal.type, array);
 }
 
 export function LiteralPanelDetails({

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -1,5 +1,6 @@
-import * as CSV from 'papaparse';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import circularSafeStringify from 'json-stringify-safe';
+import * as CSV from 'papaparse';
 import * as React from 'react';
 
 import { MODE_FEATURES } from '../shared/constants';
@@ -268,11 +269,22 @@ export function Panel({
             )}
             <span className="panel-controls vertical-align-center flex-right">
               <span className="last-run">
-                {results.loading
-                  ? 'Running...'
-                  : results.lastRun
-                  ? 'Last run ' + results.lastRun
-                  : 'Run to apply changes'}
+                {results.loading ? (
+                  'Running...'
+                ) : results.lastRun ? (
+                  <>
+                    <span
+                      className={
+                        results.exception ? 'text-failure' : 'text-success'
+                      }
+                    >
+                      {results.exception ? 'Failed' : 'Succeeded'}
+                    </span>{' '}
+                    {formatDistanceToNow(results.lastRun, { addSuffix: true })}
+                  </>
+                ) : (
+                  'Run to apply changes'
+                )}
               </span>
               <span title="Evaluate Panel (Ctrl-Enter)">
                 <Button

--- a/ui/scripts/watch_and_serve.sh
+++ b/ui/scripts/watch_and_serve.sh
@@ -2,5 +2,11 @@
 
 set -eux
 
+# Build once up front
+yarn build-ui
+
+# Now watch for changes in the background and rebuild
 fswatch -x --event Created --event Removed --event Renamed --event Updated ./ui ./shared | grep --line-buffered -E "\\.(tsx|css|ts|js|jsx)" | xargs -n1 bash -c 'yarn esbuild ui/app.tsx --loader:.ts=tsx --loader:.js=jsx --bundle --sourcemap --outfile=build/ui.js && cp ui/style.css build/style.css' &
+
+# Serve the pages
 python3 -m http.server --directory build 8080

--- a/ui/style.css
+++ b/ui/style.css
@@ -59,7 +59,7 @@ header a {
 
 .editor {
   width: 100%;
-  min-height: 500px;
+  min-height: 350px;
   height: 100% !important;
   border: 0;
   font-family: monospace;

--- a/ui/style.css
+++ b/ui/style.css
@@ -436,6 +436,14 @@ header > div {
   color: #777;
 }
 
+.text-success {
+  color: #129412;
+}
+
+.text-failure {
+  color: #a00505;
+}
+
 .form-row {
   padding: 5px 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,6 +1564,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"


### PR DESCRIPTION
This PR:

* Changes the reading excels to only show the sheets and not all metadata about the file
  * If the excel file only has one sheet, it will flatten the structure to only show that one sheet
  * Otherwise the result of the excel file evaluated will be a key-value pair of sheet names to sheet values
* Correctly handle the importing of parquet files (will only work on desktop because parquet.js is limited like that)
* Switch to date-fns for showing relative time in panel completion
* Show success/failure in panel status to help if the Exception box is scrolled out of view
![image](https://user-images.githubusercontent.com/3925912/125831549-c0797494-7e9e-4b3b-bc0d-3c096c72a97e.png)
![image](https://user-images.githubusercontent.com/3925912/125831471-cadf904d-5d78-4780-aa4f-65cffb85d5aa.png)
