### PR TITLE
Correctly handle multiple projects by always passing projectId in rpc calls

### DIFF
--- a/desktop/file.ts
+++ b/desktop/file.ts
@@ -13,6 +13,7 @@ export const evalFileHandler = {
   resource: 'evalFile',
   handler: async function (
     _: string,
+    _1: string,
     {
       contentTypeInfo,
       name,

--- a/desktop/http.ts
+++ b/desktop/http.ts
@@ -14,7 +14,11 @@ export const additionalParsers = {
 
 export const evalHTTPHandler = {
   resource: 'evalHTTP',
-  handler: async function (body: string, hci: Proxy<HTTPConnectorInfo>) {
+  handler: async function (
+    _: string,
+    body: string,
+    hci: Proxy<HTTPConnectorInfo>
+  ) {
     const url = new URL(
       (hci.http.url.startsWith('http') ? '' : 'http://') + hci.http.url
     );

--- a/desktop/preload.ts
+++ b/desktop/preload.ts
@@ -9,13 +9,14 @@ contextBridge.exposeInMainWorld('asyncRPC', async function <
   Request,
   Args,
   Response
->(resource: string, args?: Args, body?: Request) {
+>(resource: string, projectId: string, args?: Args, body?: Request) {
   const payload = {
     // Assign a new message number
     messageNumber: ++messageNumber,
     resource,
     args,
     body,
+    projectId,
   };
   ipcRenderer.send(RPC_ASYNC_REQUEST, payload);
 

--- a/desktop/program.ts
+++ b/desktop/program.ts
@@ -11,7 +11,7 @@ import { parseArrayBuffer } from '../shared/text';
 
 import { DISK_ROOT } from './constants';
 import { SETTINGS } from './settings';
-import { getCurrentProjectResultsFile } from './store';
+import { getProjectResultsFile } from './store';
 
 const runningProcesses: Record<string, number> = {};
 
@@ -77,7 +77,11 @@ const PREAMBLE = {
 export const programHandlers = [
   {
     resource: 'evalProgram',
-    handler: async function (_: string, ppi: ProgramPanelInfo) {
+    handler: async function (
+      projectId: string,
+      _: string,
+      ppi: ProgramPanelInfo
+    ) {
       const programTmp = await makeTmpFile();
       const outputTmp = await makeTmpFile();
 
@@ -89,7 +93,7 @@ export const programHandlers = [
         julia: SETTINGS.juliaPath,
       }[ppi.program.type];
 
-      const projectResultsFile = getCurrentProjectResultsFile();
+      const projectResultsFile = getProjectResultsFile(projectId);
 
       let out = '';
       try {
@@ -179,7 +183,7 @@ export const programHandlers = [
   },
   {
     resource: 'killProcess',
-    handler: async function (_: string, ppi: ProgramPanelInfo) {
+    handler: async function (_: string, _1: string, ppi: ProgramPanelInfo) {
       const pid = runningProcesses[ppi.id];
       if (pid) {
         process.kill(pid);

--- a/desktop/project.ts
+++ b/desktop/project.ts
@@ -139,5 +139,5 @@ export async function openProject() {
 
 export const openProjectHandler = {
   resource: 'openProject',
-  handler: (_1: string, _2: any) => openProject,
+  handler: (_0: string, _1: string, _2: any) => openProject,
 };

--- a/desktop/project.ts
+++ b/desktop/project.ts
@@ -28,7 +28,7 @@ const menuTemplate = [
       {
         label: 'Open Project',
         click: openProject,
-	accelerator: 'CmdOrCtrl+O',
+        accelerator: 'CmdOrCtrl+O',
       },
     ],
   },

--- a/desktop/project.ts
+++ b/desktop/project.ts
@@ -28,6 +28,7 @@ const menuTemplate = [
       {
         label: 'Open Project',
         click: openProject,
+	accelerator: 'CmdOrCtrl+O',
       },
     ],
   },

--- a/desktop/rpc.ts
+++ b/desktop/rpc.ts
@@ -6,13 +6,14 @@ import log from '../shared/log';
 interface RPCPayload {
   messageNumber: number;
   resource: string;
+  projectId: string;
   body: any;
   args: any;
 }
 
 export interface RPCHandler {
   resource: string;
-  handler: (args: any, body: any) => Promise<any>;
+  handler: (projectId: string, args: any, body: any) => Promise<any>;
 }
 
 export function registerRPCHandlers(
@@ -31,7 +32,11 @@ export function registerRPCHandlers(
           throw new Error(`No RPC handler for resource: ${payload.resource}`);
         }
 
-        const rsp = await handler.handler(payload.args, payload.body);
+        const rsp = await handler.handler(
+          payload.projectId,
+          payload.args,
+          payload.body
+        );
         event.sender.send(responseChannel, {
           body: rsp,
         });

--- a/desktop/sql.ts
+++ b/desktop/sql.ts
@@ -59,7 +59,11 @@ const DEFAULT_PORT = {
 
 export const evalSQLHandler = {
   resource: 'evalSQL',
-  handler: async function (content: string, info: Proxy<SQLConnectorInfo>) {
+  handler: async function (
+    _: string,
+    content: string,
+    info: Proxy<SQLConnectorInfo>
+  ) {
     const port = +info.sql.address.split(':')[1] || DEFAULT_PORT[info.sql.type];
     const host = info.sql.address.split(':')[0];
 

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -43,13 +43,11 @@ function flushUnwritten() {
   process.on(sig, flushUnwritten)
 );
 
-export function getCurrentProjectResultsFile() {
-  const projectFullPath: string = (BrowserWindow.getFocusedWindow() as any)
-    .DS_project;
+export function getProjectResultsFile(projectId: string) {
   const fileName = path
-    .basename(projectFullPath)
+    .basename(projectId)
     .replace('.' + PROJECT_EXTENSION, '');
-  const directory = path.dirname(projectFullPath);
+  const directory = path.dirname(projectId);
   return path.join(directory, '.' + fileName + '.results');
 }
 
@@ -69,18 +67,18 @@ export const storeHandlers = [
   },
   {
     resource: 'updateProjectState',
-    handler: async (projectId: string, newState: ProjectState) => {
+    handler: async (projectId: string, _: string, newState: ProjectState) => {
       const fileName = await ensureProjectFile(projectId);
       return writeFileBuffered(fileName, JSON.stringify(newState));
     },
   },
   {
     resource: 'storeResults',
-    handler: async function (_: string, results: any) {
+    handler: async function (projectId: string, _: string, results: any) {
       if (!results) {
         return;
       }
-      const resultsFile = getCurrentProjectResultsFile();
+      const resultsFile = getProjectResultsFile(projectId);
       const fileName = await ensureFile(resultsFile);
       // Don't use buffered write
       await fsPromises.writeFile(fileName, JSON.stringify(results));

--- a/desktop/store.ts
+++ b/desktop/store.ts
@@ -47,8 +47,7 @@ export function getProjectResultsFile(projectId: string) {
   const fileName = path
     .basename(projectId)
     .replace('.' + PROJECT_EXTENSION, '');
-  const directory = path.dirname(projectId);
-  return path.join(directory, '.' + fileName + '.results');
+  return path.join(DISK_ROOT, '.' + fileName + '.results');
 }
 
 export const storeHandlers = [

--- a/ui/ContentTypePicker.tsx
+++ b/ui/ContentTypePicker.tsx
@@ -4,7 +4,7 @@ import { XLSX_MIME_TYPE } from '../shared/text';
 import { ContentTypeInfo } from '../shared/state';
 
 import { Select } from './component-library/Select';
-import { CodeEditor } from './component-library/CodeEditor';
+import { Input } from './component-library/Input';
 
 export function ContentTypePicker({
   value,
@@ -54,10 +54,10 @@ export function ContentTypePicker({
         </Select>
       </div>
       {value.type === 'text/regexplines' && (
-        <div className="form-row regexpcode">
-          <CodeEditor
-            id=""
-            language=""
+        <div className="form-row">
+          <Input
+            autoWidth
+            type="text"
             value={value.customLineRegexp}
             onChange={(customLineRegexp: string) =>
               onChange({ ...value, customLineRegexp })

--- a/ui/ContentTypePicker.tsx
+++ b/ui/ContentTypePicker.tsx
@@ -54,7 +54,7 @@ export function ContentTypePicker({
         </Select>
       </div>
       {value.type === 'text/regexplines' && (
-        <div className="form-row">
+        <div className="form-row regexpcode">
           <CodeEditor
             id=""
             language=""

--- a/ui/ProgramPanel.tsx
+++ b/ui/ProgramPanel.tsx
@@ -89,10 +89,10 @@ export function ProgramPanelDetails({
     { value: 'python', name: 'Python' },
     ...(MODE_FEATURES.extraLanguages
       ? [
-        { value: 'ruby', name: 'Ruby' },
-        { value: 'r', name: 'R' },
-        { value: 'julia', name: 'Julia' },
-      ]
+          { value: 'ruby', name: 'Ruby' },
+          { value: 'r', name: 'R' },
+          { value: 'julia', name: 'Julia' },
+        ]
       : []),
   ];
   return (
@@ -109,16 +109,18 @@ export function ProgramPanelDetails({
                   if (panelIndex === 0) {
                     panel.content = 'DM_setPanel([])';
                   } else {
-                    panel.content = `const previous = DM_getPanel(${panelIndex - 1
-                      });\nDM_setPanel(previous);`;
+                    panel.content = `const previous = DM_getPanel(${
+                      panelIndex - 1
+                    });\nDM_setPanel(previous);`;
                   }
                   return;
                 case 'python':
                   if (panelIndex === 0) {
                     panel.content = 'DM_setPanel([])';
                   } else {
-                    panel.content = `previous = DM_getPanel(${panelIndex - 1
-                      })\nDM_setPanel(previous)`;
+                    panel.content = `previous = DM_getPanel(${
+                      panelIndex - 1
+                    })\nDM_setPanel(previous)`;
                   }
                   return;
               }

--- a/ui/ProgramPanel.tsx
+++ b/ui/ProgramPanel.tsx
@@ -61,9 +61,9 @@ export function evalProgramPanel(
         console.log = print;
         try {
           const program =
-            'from browser import window\nprint = lambda *args: window.console.log(*args)\nDM_getPanel = window.DM_getPanel\nDM_setPanel = window.DM_setPanel\n' +
+            'import js as window\nprint = lambda *args: window.console.log(*args)\nDM_getPanel = window.DM_getPanel\nDM_setPanel = window.DM_setPanel\n' +
             panel.content;
-          eval(anyWindow.__BRYTHON__.python_to_js(program));
+          (window as any).pyodide.runPython(program);
         } catch (e) {
           reject(e);
         } finally {
@@ -89,10 +89,10 @@ export function ProgramPanelDetails({
     { value: 'python', name: 'Python' },
     ...(MODE_FEATURES.extraLanguages
       ? [
-          { value: 'ruby', name: 'Ruby' },
-          { value: 'r', name: 'R' },
-          { value: 'julia', name: 'Julia' },
-        ]
+        { value: 'ruby', name: 'Ruby' },
+        { value: 'r', name: 'R' },
+        { value: 'julia', name: 'Julia' },
+      ]
       : []),
   ];
   return (
@@ -109,18 +109,16 @@ export function ProgramPanelDetails({
                   if (panelIndex === 0) {
                     panel.content = 'DM_setPanel([])';
                   } else {
-                    panel.content = `const previous = DM_getPanel(${
-                      panelIndex - 1
-                    });\nDM_setPanel(previous);`;
+                    panel.content = `const previous = DM_getPanel(${panelIndex - 1
+                      });\nDM_setPanel(previous);`;
                   }
                   return;
                 case 'python':
                   if (panelIndex === 0) {
                     panel.content = 'DM_setPanel([])';
                   } else {
-                    panel.content = `previous = DM_getPanel(${
-                      panelIndex - 1
-                    })\nDM_setPanel(previous)`;
+                    panel.content = `previous = DM_getPanel(${panelIndex - 1
+                      })\nDM_setPanel(previous)`;
                   }
                   return;
               }

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -36,13 +36,13 @@ window.onload = function() {
     return;
   }
 
-  const bmin = document.createElement('script');
-  bmin.src = 'https://cdn.jsdelivr.net/npm/brython@3.9/brython.min.js';
-  document.body.appendChild(bmin);
+  const pyodide = document.createElement('script');
+  pyodide.src = 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js';
+  document.body.appendChild(pyodide);
 
-  const bstdlib = document.createElement('script');
-  bstdlib.src = 'https://cdn.jsdelivr.net/npm/brython@3.9/brython_stdlib.js';
-  document.body.appendChild(bstdlib);
+  pyodide.onload = function() {
+    (window as any).loadPyodide({ indexURL: "https://cdn.jsdelivr.net/pyodide/v0.17.0/full/" });
+  }
 };
 
 function getQueryParameter(param: String) {

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -31,7 +31,7 @@ import { Button } from './component-library/Button';
 import { Input } from './component-library/Input';
 
 // Load brython on startup if in browser app
-document.onload = function () {
+window.onload = function() {
   if (MODE !== 'browser') {
     return;
   }
@@ -106,7 +106,7 @@ function useProjectState(
     MODE_FEATURES.useDefaultProject &&
     projectId === DEFAULT_PROJECT.projectName;
 
-  React.useEffect(() => {}, []);
+  React.useEffect(() => { }, []);
 
   // Set up undo mechanism
   React.useEffect(() => {
@@ -167,8 +167,8 @@ function App() {
   const shareState = getShareState();
   const [projectId, setProjectIdInternal] = React.useState(
     (shareState && shareState.id) ||
-      getQueryParameter('project') ||
-      (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
+    getQueryParameter('project') ||
+    (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
   (window as any).projectId = projectId;
 
@@ -301,7 +301,7 @@ function App() {
                         If you make changes, you will need to click "Share"
                         again to get a new URL.
                       </p>
-                      <Input readOnly value={shareURL} onChange={() => {}} />
+                      <Input readOnly value={shareURL} onChange={() => { }} />
                       <p>
                         <a href="https://tinyurl.com/app">TinyURL</a> is a good
                         service for shortening these URLs correctly, some other

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -31,7 +31,7 @@ import { Button } from './component-library/Button';
 import { Input } from './component-library/Input';
 
 // Load brython on startup if in browser app
-window.onload = function() {
+window.onload = function () {
   if (MODE !== 'browser') {
     return;
   }
@@ -40,9 +40,11 @@ window.onload = function() {
   pyodide.src = 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js';
   document.body.appendChild(pyodide);
 
-  pyodide.onload = function() {
-    (window as any).loadPyodide({ indexURL: "https://cdn.jsdelivr.net/pyodide/v0.17.0/full/" });
-  }
+  pyodide.onload = function () {
+    (window as any).loadPyodide({
+      indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/',
+    });
+  };
 };
 
 function getQueryParameter(param: String) {
@@ -106,7 +108,7 @@ function useProjectState(
     MODE_FEATURES.useDefaultProject &&
     projectId === DEFAULT_PROJECT.projectName;
 
-  React.useEffect(() => { }, []);
+  React.useEffect(() => {}, []);
 
   // Set up undo mechanism
   React.useEffect(() => {
@@ -167,8 +169,8 @@ function App() {
   const shareState = getShareState();
   const [projectId, setProjectIdInternal] = React.useState(
     (shareState && shareState.id) ||
-    getQueryParameter('project') ||
-    (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
+      getQueryParameter('project') ||
+      (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
   (window as any).projectId = projectId;
 
@@ -301,7 +303,7 @@ function App() {
                         If you make changes, you will need to click "Share"
                         again to get a new URL.
                       </p>
-                      <Input readOnly value={shareURL} onChange={() => { }} />
+                      <Input readOnly value={shareURL} onChange={() => {}} />
                       <p>
                         <a href="https://tinyurl.com/app">TinyURL</a> is a good
                         service for shortening these URLs correctly, some other

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -170,6 +170,7 @@ function App() {
       getQueryParameter('project') ||
       (MODE_FEATURES.useDefaultProject ? DEFAULT_PROJECT.projectName : '')
   );
+  (window as any).projectId = projectId;
 
   function setProjectId(projectId: string) {
     setProjectIdInternal(projectId);

--- a/ui/asyncRPC.ts
+++ b/ui/asyncRPC.ts
@@ -1,6 +1,16 @@
 // Simple stub for TypeScript as prepared by preload.ts.
-export const asyncRPC = (window as any).asyncRPC as <Request, Args, Response>(
+export function asyncRPC<Request, Args, Response>(
   resource: string,
   args?: Args,
   body?: Request
-) => Promise<Response>;
+): Promise<Response> {
+  const arpc = (window as any).asyncRPC as <Request, Args, Response>(
+    resource: string,
+    projectId: string,
+    args?: Args,
+    body?: Request
+  ) => Promise<Response>;
+  const projectId = (window as any).projectId;
+
+  return arpc(resource, projectId, args, body);
+}

--- a/ui/component-library/CodeEditor.tsx
+++ b/ui/component-library/CodeEditor.tsx
@@ -25,6 +25,7 @@ export function CodeEditor({
   onKeyDown,
   language,
   id,
+  singleLine,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -33,6 +34,7 @@ export function CodeEditor({
   onKeyDown?: (e: React.KeyboardEvent) => void;
   language: string;
   id: string;
+  singleLine?: boolean;
 }) {
   const [localValue, setLocalValue] = useDebouncedLocalState(value, onChange);
 
@@ -41,10 +43,11 @@ export function CodeEditor({
       <AceEditor
         mode={language}
         theme="github"
+        maxLines={singleLine ? 1 : undefined}
         onChange={setLocalValue}
         name={id}
         value={localValue}
-        className={className}
+        className={`${className} ${singleLine ? 'input' : ''}`}
         readOnly={disabled}
         width="100%"
         fontSize="1rem"
@@ -60,9 +63,22 @@ export function CodeEditor({
                 code: 'Enter',
               } as React.KeyboardEvent),
           },
-        ]}
-        showGutter={true}
+          singleLine
+            ? {
+                name: 'disable newlines',
+                bindKey: { win: 'Enter|Shift-Enter', mac: 'Enter|Shift-Enter' },
+                // Do nothing
+                exec: () => {},
+              }
+            : undefined,
+        ].filter(Boolean)}
+        showGutter={!singleLine}
         keyboardHandler="emacs"
+        setOptions={
+          singleLine
+            ? { showLineNumbers: false, highlightActiveLine: false }
+            : undefined
+        }
       />
     </div>
   );

--- a/ui/component-library/Input.tsx
+++ b/ui/component-library/Input.tsx
@@ -5,7 +5,7 @@ export function useDebouncedLocalState(
   nonLocalValue: string,
   nonLocalSet: (v: string) => void,
   isText: boolean = true,
-  delay: number = 250
+  delay: number = 125
 ): [string, (v: string) => void] {
   if (!isText) {
     return [nonLocalValue, nonLocalSet];

--- a/ui/style.css
+++ b/ui/style.css
@@ -68,7 +68,7 @@ header a {
 }
 
 .regexpcode .editor {
-    min-height: auto;
+  min-height: auto;
 }
 
 .textarea {

--- a/ui/style.css
+++ b/ui/style.css
@@ -50,12 +50,14 @@ header a {
   font-style: italic;
 }
 
+/*
+NOT SURE IF THIS IS STILL NEEDED
 .editor-container {
-  height: 200px;
   resize: vertical;
   overflow: auto;
   flex: 1;
 }
+*/
 
 .editor {
   width: 100%;
@@ -67,10 +69,6 @@ header a {
   counter-reset: line;
 }
 
-.regexpcode .editor {
-  min-height: auto;
-}
-
 .textarea {
   padding: 5px;
   background: transparent;
@@ -80,6 +78,7 @@ header a {
   max-width: 100%;
 }
 
+.editor-container .input,
 input.input,
 label.input input,
 select.select,
@@ -389,6 +388,10 @@ header > div {
 .new-panel {
   text-align: center;
   margin-bottom: 15px;
+}
+
+.panel p {
+  max-width: 800px;
 }
 
 .last-run {

--- a/ui/style.css
+++ b/ui/style.css
@@ -67,6 +67,10 @@ header a {
   counter-reset: line;
 }
 
+.regexpcode .editor {
+    min-height: auto;
+}
+
 .textarea {
   padding: 5px;
   background: transparent;


### PR DESCRIPTION
This PR:

* Set and get results file based on projectId passed in every rpc call
* Switches out brython for pyodide that gives meaningful stack traces and doesn't have tons of silly wrapper objects
* Kill all running processes by panel when the panel is run