### PR TITLE
Support for preview resizing

### DIFF
--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -590,7 +590,7 @@ export function Panel({
                 )}
               </div>
               {previewableTypes.includes(panel.type) && (
-                <div className="panel-out">
+                <div className="panel-out resize resize--left resize--horizontal">
                   <div className="panel-out-header">
                     <Button
                       className={panelOut === 'preview' ? 'selected' : ''}

--- a/ui/style.css
+++ b/ui/style.css
@@ -175,6 +175,23 @@ label.input input[type='file'] {
   color: #ccc;
 }
 
+.resize {
+  resize: both;
+  overflow: auto;
+}
+
+.resize--horizontal {
+  resize: horizontal;
+}
+
+.resize--left {
+  direction: rtl;
+}
+
+.resize--left * {
+  direction: ltr;
+}
+
 .flex-right {
   margin-left: auto;
 }
@@ -317,6 +334,11 @@ header > div {
   padding: 15px;
 }
 
+.panel-body-container {
+  overflow: auto;
+  resize: vertical;
+}
+
 .panel-controls .button {
   margin-left: 15px;
 }
@@ -332,17 +354,13 @@ header > div {
   max-width: 100%;
 }
 
-.panel-body-container {
-  overflow: auto;
-  resize: vertical;
-}
-
 .panel-body {
   padding: 15px;
   position: relative;
-  width: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
 }
 
 .panel-order {
@@ -356,7 +374,6 @@ header > div {
   padding: 5px;
   color: white;
   width: 400px;
-  max-width: 50%;
   overflow: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
It was difficult to integrate [RnD](https://github.com/bokuweb/react-rnd) without messing up the panel layout and I discovered this hack for flipping the resize button over to the other side. It works out well enough!

![image](https://user-images.githubusercontent.com/3925912/129750771-8f94f0a0-3813-44ca-9a0f-99bb4c644e41.png)
