### PR TITLE
Stable label colors

### DIFF
--- a/shared/state.ts
+++ b/shared/state.ts
@@ -321,12 +321,18 @@ export interface GraphY {
 
 export type GraphPanelInfoType = 'bar' | 'pie';
 
+export type GraphPanelInfoWidth = 'small' | 'medium' | 'large';
+
 export class GraphPanelInfo extends PanelInfo {
   graph: {
     panelSource: string;
     ys: Array<GraphY>;
     x: string;
     type: GraphPanelInfoType;
+    width: GraphPanelInfoWidth;
+    colors: {
+      unique: boolean;
+    };
   };
 
   constructor(
@@ -340,6 +346,10 @@ export class GraphPanelInfo extends PanelInfo {
       x: defaults.x || '',
       ys: defaults.ys || [],
       type: defaults.type || 'bar',
+      width: defaults.width || 'small',
+      colors: defaults.color || {
+        unique: false,
+      },
     };
   }
 }

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -347,7 +347,7 @@ export class GraphPanelInfo extends PanelInfo {
       ys: defaults.ys || [],
       type: defaults.type || 'bar',
       width: defaults.width || 'small',
-      colors: defaults.color || {
+      colors: defaults.colors || {
         unique: false,
       },
     };

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -319,7 +319,7 @@ export interface GraphY {
   label: string;
 }
 
-export type GraphPanelInfoType = 'bar' | 'pie';
+export type GraphPanelInfoType = 'bar' | 'pie' | 'line';
 
 export type GraphPanelInfoWidth = 'small' | 'medium' | 'large';
 

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -98,7 +98,7 @@ export function Input({
   if (label) {
     return (
       <label className={inputClass + ' vertical-align-center'}>
-        {label}
+        <span className="input-label">{label}</span>
         {input}
       </label>
     );

--- a/ui/components/Radio.tsx
+++ b/ui/components/Radio.tsx
@@ -6,7 +6,7 @@ export interface RadioProps extends InputProps {
   vertical?: boolean;
 }
 
-export function Radio({ options, value, vertical, ...props }: RadioProps) {
+export function Radio({ options, value, label, vertical, ...props }: RadioProps) {
   React.useEffect(() => {
     if (!options.length) {
       return;
@@ -17,8 +17,10 @@ export function Radio({ options, value, vertical, ...props }: RadioProps) {
     }
   });
 
-  return (
-    <span className={`radio ${vertical ? 'radio--vertical' : ''}`}>
+  const radioClass = "radio";
+
+  const radio = (
+    <span className={(label ? '' : radioClass + ' ') + (vertical ? '' : 'vertical-align-center')}>
       {options.map((o) => (
         <Input
           className="radio-element"
@@ -32,4 +34,15 @@ export function Radio({ options, value, vertical, ...props }: RadioProps) {
       ))}
     </span>
   );
+
+  if (label) {
+    return (
+      <label className={radioClass + ' vertical-align-center'}>
+        <span className="radio-label">{label}</span>
+        {radio}
+      </label>
+    );
+  }
+
+  return radio;
 }

--- a/ui/components/Radio.tsx
+++ b/ui/components/Radio.tsx
@@ -6,7 +6,13 @@ export interface RadioProps extends InputProps {
   vertical?: boolean;
 }
 
-export function Radio({ options, value, label, vertical, ...props }: RadioProps) {
+export function Radio({
+  options,
+  value,
+  label,
+  vertical,
+  ...props
+}: RadioProps) {
   React.useEffect(() => {
     if (!options.length) {
       return;
@@ -17,10 +23,15 @@ export function Radio({ options, value, label, vertical, ...props }: RadioProps)
     }
   });
 
-  const radioClass = "radio";
+  const radioClass = 'radio';
 
   const radio = (
-    <span className={(label ? '' : radioClass + ' ') + (vertical ? '' : 'vertical-align-center')}>
+    <span
+      className={
+        (label ? '' : radioClass + ' ') +
+        (vertical ? '' : 'vertical-align-center')
+      }
+    >
       {options.map((o) => (
         <Input
           className="radio-element"

--- a/ui/components/Select.tsx
+++ b/ui/components/Select.tsx
@@ -101,7 +101,7 @@ export function Select({
   if (label) {
     return (
       <label className={selectClass}>
-        {label}
+        <span className="select-label">{label}</span>
         {select}
       </label>
     );

--- a/ui/panels/GraphPanel.tsx
+++ b/ui/panels/GraphPanel.tsx
@@ -363,8 +363,9 @@ export function GraphPanelDetails({
                   updatePanel(panel);
                 }}
               >
-                <option value="bar">Bar</option>
-                <option value="pie">Pie</option>
+                <option value="bar">Bar Chart</option>
+                <option value="line">Line Chart</option>
+                <option value="pie">Pie Chart</option>
               </Select>
             </div>
             <div className="form-row">

--- a/ui/panels/GraphPanel.tsx
+++ b/ui/panels/GraphPanel.tsx
@@ -182,6 +182,18 @@ export function GraphPanel({ panel, panels }: PanelBodyProps<GraphPanelInfo>) {
       ],
       options: {
         responsive: true,
+        plugins: {
+          legend: {
+	    title: {
+	      display: true,
+	      text: panel.name,
+	    },
+            labels: {
+	      // Hide legend unless there are multiple Y-es
+	      generateLabels: panel.graph.ys.length < 2 ? () => '' : undefined,
+            },
+          },
+        },
       },
       type: panel.graph.type,
       data: {
@@ -227,7 +239,16 @@ export function GraphPanel({ panel, panels }: PanelBodyProps<GraphPanelInfo>) {
     });
 
     return () => chart.destroy();
-  }, [ref.current, data, panel.graph.x, panel.graph.ys, panel.graph.type, panel.graph.colors.unique, panel.graph.width]);
+  }, [
+    ref.current,
+    data,
+    panel.graph.name,
+    panel.graph.x,
+    panel.graph.ys,
+    panel.graph.type,
+    panel.graph.colors.unique,
+    panel.graph.width,
+  ]);
 
   if (!value || !value.length) {
     return null;
@@ -358,8 +379,8 @@ export function GraphPanelDetails({
                   { label: 'No', value: 'false' },
                 ]}
               />
-      </div>
-    <div className="form-row">
+            </div>
+            <div className="form-row">
               <Radio
                 label="Width"
                 value={panel.graph.width}
@@ -367,9 +388,9 @@ export function GraphPanelDetails({
                   panel.graph.width = value as GraphPanelInfoWidth;
                   updatePanel(panel);
                 }}
-    options={[
-      { label: 'Small', value: 'small' },
-      { label: 'Medium', value: 'medium' },
+                options={[
+                  { label: 'Small', value: 'small' },
+                  { label: 'Medium', value: 'medium' },
                   { label: 'Large', value: 'large' },
                 ]}
               />

--- a/ui/panels/GraphPanel.tsx
+++ b/ui/panels/GraphPanel.tsx
@@ -184,13 +184,14 @@ export function GraphPanel({ panel, panels }: PanelBodyProps<GraphPanelInfo>) {
         responsive: true,
         plugins: {
           legend: {
-	    title: {
-	      display: true,
-	      text: panel.name,
-	    },
+            title: {
+              display: true,
+              text: panel.name,
+            },
             labels: {
-	      // Hide legend unless there are multiple Y-es
-	      generateLabels: panel.graph.ys.length < 2 ? () => '' : undefined,
+              // Hide legend unless there are multiple Y-es
+              generateLabels:
+                panel.graph.ys.length < 2 ? ((() => '') as any) : undefined,
             },
           },
         },
@@ -242,7 +243,7 @@ export function GraphPanel({ panel, panels }: PanelBodyProps<GraphPanelInfo>) {
   }, [
     ref.current,
     data,
-    panel.graph.name,
+    panel.name,
     panel.graph.x,
     panel.graph.ys,
     panel.graph.type,
@@ -369,7 +370,7 @@ export function GraphPanelDetails({
             <div className="form-row">
               <Radio
                 label="Unique Colors"
-                value={panel.graph.colors.unique}
+                value={String(panel.graph.colors.unique)}
                 onChange={(value: string) => {
                   panel.graph.colors.unique = value === 'true';
                   updatePanel(panel);

--- a/ui/style.css
+++ b/ui/style.css
@@ -105,7 +105,10 @@ header iframe {
   max-width: 100%;
 }
 
-label, .radio-label, .input-label, .select-label {
+label,
+.radio-label,
+.input-label,
+.select-label {
   padding-right: 15px;
   color: #777;
   font-size: 0.75rem;
@@ -118,9 +121,9 @@ input[type='radio'] {
 
 .radio {
   .input-label {
-      padding-right: 5px;
-      font-size: initial;
-      color: initial;
+    padding-right: 5px;
+    font-size: initial;
+    color: initial;
   }
 }
 
@@ -466,8 +469,8 @@ header > div {
 }
 
 .panel-details {
-    margin: 15px auto 0 auto;
-    max-width: 1024px;
+  margin: 15px auto 0 auto;
+  max-width: 1024px;
 }
 
 .panel-details label.select select,
@@ -706,21 +709,21 @@ header > div {
 }
 
 canvas {
-    max-height: 100%;
-    margin: 30px auto;
+  max-height: 100%;
+  margin: 30px auto;
 }
 
 .canvas--small {
-    width: 1024px !important;
-    max-width: 100%;
+  width: 1024px !important;
+  max-width: 100%;
 }
 
 .canvas--medium {
-    width: 75% !important;
+  width: 75% !important;
 }
 
 .canvas--large {
-    width: 100% !important;
+  width: 100% !important;
 }
 
 .modal {

--- a/ui/style.css
+++ b/ui/style.css
@@ -105,7 +105,7 @@ header iframe {
   max-width: 100%;
 }
 
-label {
+label, .radio-label, .input-label, .select-label {
   padding-right: 15px;
   color: #777;
   font-size: 0.75rem;
@@ -116,8 +116,12 @@ input[type='radio'] {
   margin-left: 3px;
 }
 
-.radio--vertical {
-  display: block;
+.radio {
+  .input-label {
+      padding-right: 5px;
+      font-size: initial;
+      color: initial;
+  }
 }
 
 .radio--vertical .radio-element {
@@ -462,7 +466,8 @@ header > div {
 }
 
 .panel-details {
-  margin-top: 15px;
+    margin: 15px auto 0 auto;
+    max-width: 1024px;
 }
 
 .panel-details label.select select,
@@ -701,7 +706,21 @@ header > div {
 }
 
 canvas {
-  max-height: 100%;
+    max-height: 100%;
+    margin: 30px auto;
+}
+
+.canvas--small {
+    width: 1024px !important;
+    max-width: 100%;
+}
+
+.canvas--medium {
+    width: 75% !important;
+}
+
+.canvas--large {
+    width: 100% !important;
 }
 
 .modal {


### PR DESCRIPTION
This PR:
* Makes colors stable when using colors for each label/x axis item
* Allows you to disable unique colors
* Shows the panel name in the legend (this is included when downloading the png)
* Allows you to pick graph sizes
* Adds support for line charts

![image](https://user-images.githubusercontent.com/3925912/141685437-b93d7112-8173-4f9e-aafd-87152b982d34.png)
<img width="1907" alt="Screen Shot 2021-11-14 at 8 18 20 AM" src="https://user-images.githubusercontent.com/3925912/141685419-a5386413-7848-4c00-969b-b12e5e2e7c64.png">
<img width="1811" alt="Screen Shot 2021-11-14 at 8 18 44 AM" src="https://user-images.githubusercontent.com/3925912/141685420-6bb6f222-2a2b-4aaa-a7bf-27d3605b802e.png">
