### PR TITLE
Add support for sql programs in Go runner

### DIFF
--- a/desktop/panel/eval.ts
+++ b/desktop/panel/eval.ts
@@ -17,7 +17,6 @@ import {
   PanelInfo,
   PanelInfoType,
   PanelResult,
-  ProgramPanelInfo,
   ProjectState,
 } from '../../shared/state';
 import { getMimeType } from '../../shared/text';

--- a/desktop/panel/eval.ts
+++ b/desktop/panel/eval.ts
@@ -93,10 +93,7 @@ function canUseGoRunner(panel: PanelInfo, connectors: ConnectorInfo[]) {
     return false;
   }
 
-  if (
-    panel.type === 'program' &&
-    (panel as ProgramPanelInfo).program.type !== 'sql'
-  ) {
+  if (panel.type === 'program') {
     return true;
   }
 

--- a/desktop/panel/program.test.js
+++ b/desktop/panel/program.test.js
@@ -89,10 +89,6 @@ for (const t of TESTS) {
       { node: path.join(CODE_ROOT, 'build', 'desktop_runner.js') },
       { go: path.join(CODE_ROOT, 'build', 'go_desktop_runner') },
     ]) {
-      if (t.type === 'sql' && subprocessName?.go) {
-        continue;
-      }
-
       test(`runs ${t.type} programs to perform addition via ${
         subprocessName
           ? subprocessName.node || subprocessName.go

--- a/desktop/panel/program.test.js
+++ b/desktop/panel/program.test.js
@@ -22,12 +22,12 @@ const TESTS = [
   },
   {
     type: 'sql',
-    content: 'SELECT name, age::INT + 10 AS age FROM DM_getPanel(0)',
+    content: 'SELECT name, CAST(age AS INT) + 10 AS age FROM DM_getPanel(0)',
     condition: true,
   },
   {
     type: 'sql',
-    content: `SELECT name, age::INT + 10 AS age FROM DM_getPanel('Raw Data')`,
+    content: `SELECT name, CAST(age AS INT) + 10 AS age FROM DM_getPanel('Raw Data')`,
     condition: true,
   },
   // Rest are only mandatory-tested on Linux to make CI easier for now

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go v1.5.1
 	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/google/uuid v1.3.0
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.10.4
 	github.com/mattn/go-sqlite3 v1.14.9

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -13,6 +13,8 @@ github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfC
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/runner/program.go
+++ b/runner/program.go
@@ -74,7 +74,7 @@ func evalProgramSQLPanel(project *ProjectState, pageIndex int, panel *PanelInfo)
 }
 
 func evalProgramPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
-	if panel.Program.Type == "sql" {
+	if panel.Program.Type == SQL {
 		return evalProgramSQLPanel(project, pageIndex, panel)
 	}
 

--- a/runner/program.go
+++ b/runner/program.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 type ProgramEvalInfo struct {
@@ -47,7 +49,28 @@ func evalProgramSQLPanel(project *ProjectState, pageIndex int, panel *PanelInfo)
 	}
 	defer os.Remove(tmp.Name())
 
-	return nil
+	connector := ConnectorInfo{
+		Type: DatabaseConnector,
+		Id:   uuid.New().String(),
+		DatabaseConnectorInfo: &DatabaseConnectorInfo{
+			Database: DatabaseConnectorInfoDatabase{
+				Type:     SQLiteDatabase,
+				Database: tmp.Name(),
+			},
+		},
+	}
+	project.Connectors = append(project.Connectors, connector)
+
+	return evalDatabasePanel(project, pageIndex, &PanelInfo{
+		Type:    DatabasePanel,
+		Id:      panel.Id,
+		Content: panel.Content,
+		DatabasePanelInfo: &DatabasePanelInfo{
+			Database: DatabasePanelInfoDatabase{
+				ConnectorId: connector.Id,
+			},
+		},
+	})
 }
 
 func evalProgramPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {

--- a/runner/state.go
+++ b/runner/state.go
@@ -119,13 +119,15 @@ type LiteralPanelInfo struct {
 	} `json:"literal"`
 }
 
+type DatabasePanelInfoDatabase struct {
+	ConnectorId string      `json:"connectorId"`
+	Range       interface{} `json:"range"` // TODO: support these
+	Table       string      `json:"table"`
+	Step        float64     `json:"step"`
+}
+
 type DatabasePanelInfo struct {
-	Database struct {
-		ConnectorId string      `json:"connectorId"`
-		Range       interface{} `json:"range"` // TODO: support these
-		Table       string      `json:"table"`
-		Step        float64     `json:"step"`
-	} `json:"database"`
+	Database DatabasePanelInfoDatabase `json:"database"`
 }
 
 type ConnectorInfoType string

--- a/runner/state.go
+++ b/runner/state.go
@@ -98,6 +98,7 @@ const (
 	Ruby                          = "ruby"
 	R                             = "r"
 	Julia                         = "julia"
+	SQL                           = "sql"
 )
 
 type ProgramPanelInfo struct {


### PR DESCRIPTION
This uses SQLite under the hood whereas the old runner used a PostgreSQL-inspired in-memory implementation called [AlaSQL](https://github.com/agershun/alasql).

One result of this is that postgres-style casts `age::int` don't work and you need to do ANSI SQL `cast(age as int)`. This is a breaking change but I'm ok with that.