### PR TITLE
Fix http header reader in Go runner

### DIFF
--- a/desktop/panel/http.test.js
+++ b/desktop/panel/http.test.js
@@ -208,11 +208,13 @@ for (const subprocessName of RUNNERS) {
   }
 
   if (process.platform === 'linux') {
-    describe('http with headers',() => {
+    describe('http with headers', () => {
       test('correct result', () => {
         const hp = new HTTPPanelInfo(
           '',
-          new HTTPConnectorInfo('', 'http://localhost:9799/testdata/unknown', [{name: 'X-Test', value: 'OK'}])
+          new HTTPConnectorInfo('', 'http://localhost:9799/testdata/unknown', [
+            { name: 'X-Test', value: 'OK' },
+          ])
         );
 
         const panels = [hp];
@@ -233,45 +235,42 @@ for (const subprocessName of RUNNERS) {
           },
           { evalPanels: true, subprocessName }
         );
-      })
+      });
     });
 
-    describe(
-      'eval http over server via ' +subprocessName.go,
-      () => {
-        test('correct result', () => {
-          const server = new ServerInfo({
-            address: 'localhost',
-            type: 'private-key',
-          });
-          const hp = new HTTPPanelInfo(
-            '',
-            new HTTPConnectorInfo('', 'http://localhost:9799/testdata/unknown')
-          );
-          hp.serverId = server.id;
+    describe('eval http over server via ' + subprocessName.go, () => {
+      test('correct result', () => {
+        const server = new ServerInfo({
+          address: 'localhost',
+          type: 'private-key',
+        });
+        const hp = new HTTPPanelInfo(
+          '',
+          new HTTPConnectorInfo('', 'http://localhost:9799/testdata/unknown')
+        );
+        hp.serverId = server.id;
 
-          const servers = [server];
-          const panels = [hp];
+        const servers = [server];
+        const panels = [hp];
 
-          return withSavedPanels(
-            panels,
-            (project) => {
-              // Grab result
-              const value = JSON.parse(
-                fs
-                  .readFileSync(
-                    getProjectResultsFile(project.projectName) + hp.id
-                  )
-                  .toString()
-              );
+        return withSavedPanels(
+          panels,
+          (project) => {
+            // Grab result
+            const value = JSON.parse(
+              fs
+                .readFileSync(
+                  getProjectResultsFile(project.projectName) + hp.id
+                )
+                .toString()
+            );
 
-              expect(value).toEqual('hey this is unknown');
-            },
-            { evalPanels: true, subprocessName, servers }
-          );
-        }, 30_000);
-      }
-    );
+            expect(value).toEqual('hey this is unknown');
+          },
+          { evalPanels: true, subprocessName, servers }
+        );
+      }, 30_000);
+    });
   }
 }
 

--- a/desktop/panel/http.test.js
+++ b/desktop/panel/http.test.js
@@ -32,6 +32,7 @@ const USERDATA_FILES = ['json', 'xlsx', 'csv', 'parquet', 'jsonl'];
 const PORT = '9799';
 
 let server;
+// Kill the existing server if it wasn't killed correctly already.
 beforeAll(async () => {
   // TODO: port this logic to other platforms...
   if (process.platform === 'linux') {
@@ -44,6 +45,7 @@ beforeAll(async () => {
     }
   }
 
+  // Start a new server for all tests
   server = spawn('python3', ['-m', 'http.server', PORT]);
   let ready = false;
   server.on('spawn', () => {
@@ -206,9 +208,36 @@ for (const subprocessName of RUNNERS) {
   }
 
   if (process.platform === 'linux') {
+    describe('http with headers',() => {
+      test('correct result', () => {
+        const hp = new HTTPPanelInfo(
+          '',
+          new HTTPConnectorInfo('', 'http://localhost:9799/testdata/unknown', [{name: 'X-Test', value: 'OK'}])
+        );
+
+        const panels = [hp];
+
+        return withSavedPanels(
+          panels,
+          (project) => {
+            // Grab result
+            const value = JSON.parse(
+              fs
+                .readFileSync(
+                  getProjectResultsFile(project.projectName) + hp.id
+                )
+                .toString()
+            );
+
+            expect(value).toEqual('hey this is unknown');
+          },
+          { evalPanels: true, subprocessName }
+        );
+      })
+    });
+
     describe(
-      'eval file over server via ' +
-        (subprocessName ? subprocessName.go || subprocessName.node : 'memory'),
+      'eval http over server via ' +subprocessName.go,
       () => {
         test('correct result', () => {
           const server = new ServerInfo({

--- a/runner/http.go
+++ b/runner/http.go
@@ -126,7 +126,7 @@ func evalHttpPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error
 		}
 
 		for _, header := range h.Headers {
-			req.Header.Set(header[0], header[1])
+			req.Header.Set(header.Name, header.Value)
 		}
 
 		client := &http.Client{}

--- a/runner/state.go
+++ b/runner/state.go
@@ -285,11 +285,16 @@ type DatabaseConnectorInfo struct {
 	Database DatabaseConnectorInfoDatabase `json:"database" db:"database"`
 }
 
+type HttpConnectorInfoHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 type HttpConnectorInfoHttp struct {
-	Method          string          `json:"method" db:"method"`
-	Url             string          `json:"url" db:"url"`
-	ContentTypeInfo ContentTypeInfo `json:"contentTypeInfo" db:"contentTypeInfo"`
-	Headers         [][]string      `json:"headers" db:"headers"`
+	Method          string                    `json:"method" db:"method"`
+	Url             string                    `json:"url" db:"url"`
+	ContentTypeInfo ContentTypeInfo           `json:"contentTypeInfo" db:"contentTypeInfo"`
+	Headers         []HttpConnectorInfoHeader `json:"headers" db:"headers"`
 }
 
 type HttpConnectorInfo struct {


### PR DESCRIPTION
Pointed out by Chang Xu. There wasn't a test for this and this was broken in the runner port from JS to Go.