### PR TITLE
Performance improvements to -> JSON conversion, and improvements to JSON -> database ingestion

### DIFF
--- a/desktop/partial.ts
+++ b/desktop/partial.ts
@@ -95,13 +95,7 @@ export function parsePartialJSONFile(
       }
     }
 
-    let value: any;
-    try {
-      value = JSON.parse(f);
-    } catch (e) {
-      fs.writeFileSync('/tmp/phil2', f);
-      throw e;
-      }
+    const value = JSON.parse(f);
 
     let arrayCount = null;
     if (Array.isArray(value)) {

--- a/desktop/partial.ts
+++ b/desktop/partial.ts
@@ -95,7 +95,13 @@ export function parsePartialJSONFile(
       }
     }
 
-    const value = JSON.parse(f);
+    let value: any;
+    try {
+      value = JSON.parse(f);
+    } catch (e) {
+      fs.writeFileSync('/tmp/phil2', f);
+      throw e;
+      }
 
     let arrayCount = null;
     if (Array.isArray(value)) {

--- a/runner/database.go
+++ b/runner/database.go
@@ -420,7 +420,7 @@ func EvalDatabasePanel(
 	project *ProjectState,
 	pageIndex int,
 	panel *PanelInfo,
-	panelResultLoader func (projectId, panelId string) (chan map[string]interface{}, error),
+	panelResultLoader func(projectId, panelId string) (chan map[string]interface{}, error),
 ) error {
 	var connector *ConnectorInfo
 	for _, c := range project.Connectors {

--- a/runner/file.go
+++ b/runner/file.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/csv"
 	"encoding/json"
-	"strconv"
 	"io"
 	"io/ioutil"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/multiprocessio/go-openoffice"
@@ -37,10 +37,10 @@ func newJSONArrayWriter(w io.Writer) *JSONArrayWriter {
 }
 
 var (
-	COMMA   = []byte(",")
+	COMMA    = []byte(",")
 	COMMA_NL = []byte(",\n")
-	OPEN    = []byte("{")
-	CLOSE   = []byte("}")
+	OPEN     = []byte("{")
+	CLOSE    = []byte("}")
 )
 
 func (j *JSONArrayWriter) Write(row interface{}) error {
@@ -56,7 +56,7 @@ func (j *JSONArrayWriter) Write(row interface{}) error {
 		if j.isMap {
 			for k := range r {
 				j.columns = append(j.columns, k)
-				j.columnsEscaped = append(j.columnsEscaped, []byte(strconv.QuoteToASCII(k) +`:`))
+				j.columnsEscaped = append(j.columnsEscaped, []byte(strconv.QuoteToASCII(k)+`:`))
 			}
 		}
 	}

--- a/runner/file.go
+++ b/runner/file.go
@@ -37,15 +37,15 @@ func newJSONArrayWriter(w io.Writer) *JSONArrayWriter {
 }
 
 var (
-	comma   = []byte(",")
-	commaNl = []byte(",\n")
-	open    = []byte("{")
-	close   = []byte("}")
+	COMMA   = []byte(",")
+	COMMA_NL = []byte(",\n")
+	OPEN    = []byte("{")
+	CLOSE   = []byte("}")
 )
 
 func (j *JSONArrayWriter) Write(row interface{}) error {
 	if !j.first {
-		_, err := j.w.Write(commaNl)
+		_, err := j.w.Write(COMMA_NL)
 		if err != nil {
 			return edsef("Failed to write JSON delimiter: %s", err)
 		}
@@ -68,7 +68,7 @@ func (j *JSONArrayWriter) Write(row interface{}) error {
 	// the row is not necessarily a map is parquet.
 	if j.isMap {
 		r := row.(map[string]interface{})
-		j.w.Write(open)
+		j.w.Write(OPEN)
 		for i, col := range j.columns {
 			cellBytes, err := json.Marshal(r[col])
 			if err != nil {
@@ -77,7 +77,7 @@ func (j *JSONArrayWriter) Write(row interface{}) error {
 
 			var prefix []byte
 			if i > 0 {
-				prefix = comma
+				prefix = COMMA
 			}
 			_, err = j.w.Write(prefix)
 			if err != nil {
@@ -94,7 +94,7 @@ func (j *JSONArrayWriter) Write(row interface{}) error {
 				return edse(err)
 			}
 		}
-		j.w.Write(close)
+		j.w.Write(CLOSE)
 	} else {
 		encoder := json.NewEncoder(j.w)
 		err := encoder.Encode(row)

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"encoding/json"
+	"fmt"
+	"time"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -118,4 +120,22 @@ func Test_transformJSONConcat(t *testing.T) {
 
 		assert.Equal(t, test.out, m)
 	}
+}
+
+func Test_transformCSV_BENCHMARK(t *testing.T) {
+	if os.Getenv("BENCHMARK") != "true" {
+		return
+	}
+	
+	// curl -LO https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2021-04.csv
+	outTmp, err := ioutil.TempFile("", "")
+	defer os.Remove(outTmp.Name())
+	assert.Nil(t, err)
+
+
+	start := time.Now()
+	err = transformCSVFile("yellow_tripdata_2021-04.csv", outTmp, ',')
+	assert.Nil(t, err)
+
+	fmt.Printf("transform csv took %s\n", time.Since(start))
 }

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -3,10 +3,10 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -126,12 +126,11 @@ func Test_transformCSV_BENCHMARK(t *testing.T) {
 	if os.Getenv("BENCHMARK") != "true" {
 		return
 	}
-	
+
 	// curl -LO https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2021-04.csv
 	outTmp, err := ioutil.TempFile("", "")
 	defer os.Remove(outTmp.Name())
 	assert.Nil(t, err)
-
 
 	start := time.Now()
 	err = transformCSVFile("yellow_tripdata_2021-04.csv", outTmp, ',')

--- a/runner/http.go
+++ b/runner/http.go
@@ -128,7 +128,7 @@ func makeHTTPRequest(hr httpRequest) (*http.Response, error) {
 		req.Header.Set(header.Name, header.Value)
 	}
 
-	c := http.Client{Timeout: time.Second * 5}
+	c := http.Client{Timeout: time.Second * 15}
 	return c.Do(req)
 }
 

--- a/runner/program.go
+++ b/runner/program.go
@@ -44,32 +44,26 @@ func getIdMapJson(page ProjectPage) string {
 	return string(bts)
 }
 
-func MakeTmpSQLiteConnector() (*ConnectorInfo, *os.File, error) {
-	tmp, err := os.CreateTemp("", "sql-program-panel-")
-	if err != nil {
-		return nil, nil, err
-	}
-
+func MakeTmpSQLiteConnector() (*ConnectorInfo, error) {
 	connector := &ConnectorInfo{
 		Type: DatabaseConnector,
 		Id:   uuid.New().String(),
 		DatabaseConnectorInfo: &DatabaseConnectorInfo{
 			Database: DatabaseConnectorInfoDatabase{
 				Type:     SQLiteDatabase,
-				Database: tmp.Name(),
+				Database: ":memory:",
 			},
 		},
 	}
 
-	return connector, tmp, nil
+	return connector, nil
 }
 
 func evalProgramSQLPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
-	connector, tmp, err := MakeTmpSQLiteConnector()
+	connector, err := MakeTmpSQLiteConnector()
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmp.Name())
 	project.Connectors = append(project.Connectors, *connector)
 
 	return EvalDatabasePanel(project, pageIndex, &PanelInfo{

--- a/runner/shape.go
+++ b/runner/shape.go
@@ -114,6 +114,7 @@ outer:
 		}
 
 		unique = append(unique, i)
+
 	}
 
 	return unique

--- a/runner/sql.go
+++ b/runner/sql.go
@@ -336,7 +336,7 @@ func importAndRun(
 			return nil, err
 		}
 
-		for resChunk := range chunk(c, 100) {
+		for resChunk := range chunk(c, 10) {
 			query, values := formatImportQueryAndRows(
 				panel.tableName,
 				panel.columns,

--- a/runner/sql.go
+++ b/runner/sql.go
@@ -282,7 +282,7 @@ func chunk(c chan map[string]interface{}, size int) chan []map[string]interface{
 	outer:
 		for {
 			select {
-			case next, ok := <- c:
+			case next, ok := <-c:
 				if !ok {
 					break outer
 				}

--- a/runner/sql.go
+++ b/runner/sql.go
@@ -271,19 +271,36 @@ func defaultMangleInsert(stmt string) string {
 	return stmt
 }
 
-func chunk(a []map[string]interface{}, size int) [][]map[string]interface{} {
-	var chunks [][]map[string]interface{}
-	for i := 0; i < len(a); i += size {
-		end := i + size
+func chunk(c chan map[string]interface{}, size int) chan []map[string]interface{} {
+	var chunk []map[string]interface{}
 
-		if end > len(a) {
-			end = len(a)
+	out := make(chan []map[string]interface{}, 1)
+
+	go func() {
+		defer close(out)
+
+	outer:
+		for {
+			select {
+			case next, ok := <- c:
+				if !ok {
+					break outer
+				}
+				chunk = append(chunk, next)
+			}
+
+			if len(chunk) == size {
+				out <- chunk
+				chunk = nil
+			}
 		}
 
-		chunks = append(chunks, a[i:end])
-	}
+		if len(chunk) > 0 {
+			out <- chunk
+		}
+	}()
 
-	return chunks
+	return out
 }
 
 func importAndRun(
@@ -296,7 +313,7 @@ func importAndRun(
 	qt quoteType,
 	// Postgres uses $1, mysql/sqlite use ?
 	mangleInsert func(string) string,
-	panelResultLoader func(string, string, interface{}) error,
+	panelResultLoader func(string, string) (chan map[string]interface{}, error),
 ) ([]map[string]interface{}, error) {
 	rowsIngested := 0
 	for _, panel := range panelsToImport {
@@ -314,16 +331,12 @@ func importAndRun(
 			return nil, err
 		}
 
-		// This is bad design, it loads the entire thing into
-		// memory and then chunks it up to be loaded into the
-		// database.
-		var res []map[string]interface{}
-		err = panelResultLoader(projectId, panel.id, &res)
+		c, err := panelResultLoader(projectId, panel.id)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, resChunk := range chunk(res, 1000) {
+		for resChunk := range chunk(c, 100) {
 			query, values := formatImportQueryAndRows(
 				panel.tableName,
 				panel.columns,

--- a/runner/sql_test.go
+++ b/runner/sql_test.go
@@ -1,8 +1,12 @@
 package runner
 
 import (
-	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_transformDM_getPanelCalls(t *testing.T) {
@@ -79,25 +83,25 @@ func Test_transformDM_getPanelCalls(t *testing.T) {
 	})
 }
 
-func Test_chunk(t *testing.T) {
-	a := []map[string]interface{}{
-		{"a": 1},
-		{"b": 2},
-		{"c": 3},
-		{"d": 4},
-		{"e": 5},
-		{"f": 6},
-		{"g": 7},
-	}
-	chunks := chunk(a, 3)
-	assert.Equal(t, len(chunks), 3)
-	assert.Equal(t, len(chunks[0]), 3)
-	assert.Equal(t, len(chunks[1]), 3)
-	assert.Equal(t, len(chunks[2]), 1)
-	assert.Equal(t, chunks[2][0], map[string]interface{}{
-		"g": 7,
-	})
-}
+// func Test_chunk(t *testing.T) {
+// 	a := []map[string]interface{}{
+// 		{"a": 1},
+// 		{"b": 2},
+// 		{"c": 3},
+// 		{"d": 4},
+// 		{"e": 5},
+// 		{"f": 6},
+// 		{"g": 7},
+// 	}
+// 	chunks := chunk(a, 3)
+// 	assert.Equal(t, len(chunks), 3)
+// 	assert.Equal(t, len(chunks[0]), 3)
+// 	assert.Equal(t, len(chunks[1]), 3)
+// 	assert.Equal(t, len(chunks[2]), 1)
+// 	assert.Equal(t, chunks[2][0], map[string]interface{}{
+// 		"g": 7,
+// 	})
+// }
 
 func Test_postgresMangleInsert(t *testing.T) {
 	assert.Equal(t,
@@ -160,4 +164,61 @@ func Test_getObjectAtPath(t *testing.T) {
 		res := getObjectAtPath(test.input, test.path)
 		assert.Equal(t, test.expected, res)
 	}
+}
+
+func Test_sqlIngest_BENCHMARK(t *testing.T) {
+	if os.Getenv("BENCHMARK") != "true" {
+		return
+	}
+
+	projectTmp, err := ioutil.TempFile("", "dsq-project")
+	assert.Nil(t, err)
+	defer os.Remove(projectTmp.Name())
+
+	project := &ProjectState{
+		Id: projectTmp.Name(),
+		Pages: []ProjectPage{
+			{
+				Panels: nil,
+			},
+		},
+	}
+
+	connector, tmp, err := MakeTmpSQLiteConnector()
+	assert.Nil(t, err)
+	defer os.Remove(tmp.Name())
+	project.Connectors = append(project.Connectors, *connector)
+
+	// curl -LO https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2021-04.csv
+	// dsq yellow_tripdata_2021-04.csv > yellow_tripdata_2021-04.json
+	readFile := "yellow_tripdata_2021-04.json"
+	//readFile := "../testdata/allformats/userdata.json"
+
+	panelId := uuid.New().String()
+	s, err := ShapeFromFile(readFile, panelId, 10_000, 100)
+	assert.Nil(t, err)
+	project.Pages[0].Panels = append(project.Pages[0].Panels, PanelInfo{
+		ResultMeta: PanelResult{
+			Shape: *s,
+		},
+		Id:   panelId,
+		Name: uuid.New().String(),
+	})
+
+	panel2 := &PanelInfo{
+		Type:    DatabasePanel,
+		Content: "SELECT COUNT(1) FROM DM_getPanel(0)",
+		Id:      uuid.New().String(),
+		Name:    uuid.New().String(),
+		DatabasePanelInfo: &DatabasePanelInfo{
+			Database: DatabasePanelInfoDatabase{
+				ConnectorId: connector.Id,
+			},
+		},
+	}
+
+	err = EvalDatabasePanel(project, 0, panel2, func(projectId, panelId string) (chan map[string]interface{}, error) {
+		return loadJSONArrayFile(readFile)
+	})
+	assert.Nil(t, err)
 }

--- a/runner/sql_test.go
+++ b/runner/sql_test.go
@@ -184,9 +184,8 @@ func Test_sqlIngest_BENCHMARK(t *testing.T) {
 		},
 	}
 
-	connector, tmp, err := MakeTmpSQLiteConnector()
+	connector, err := MakeTmpSQLiteConnector()
 	assert.Nil(t, err)
-	defer os.Remove(tmp.Name())
 	project.Connectors = append(project.Connectors, *connector)
 
 	// curl -LO https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2021-04.csv


### PR DESCRIPTION
# -> JSON conversion

Major themes:
* Buffered IO for writes (biggest change)
* Specialize when writing map[string]interface{} to avoid expensive sort.Slice by json.Marshal in write loop
* Move map allocations out of write loop
* Get rid of string->[]byte allocations in write loop

For the sample 192MB file included in a benchmark now, this brought the csv->json conversion down from 19s to 8.7s.

The other big chunk of code I need to look at is the SQL ingestion in sql.go.

To run the benchmark and generate a cpu profile:

```
BENCHMARK=true go test -cpuprofile cpu.prof -bench . -run Test_transformCSV
go tool pprof cpu.prof
```

which you can then load into https://www.speedscope.app/

# JSON -> database ingestion

Major changes:
* Streaming JSON rows into the database rather than loading all rows into memory first

This plus the above -> JSON change brings the octosql benchmark down from 69s to 41s:

```
$ time ./dsq yellow_tripdata_2021-04.csv 'SELECT passenger_count, COUNT(*), AVG(total_amount) FROM {} GROUP BY passenger_count'
[{"COUNT(*)":128020,"AVG(total_amount)":32.23715114825533,"passenger_count":""},
{"COUNT(*)":42228,"AVG(total_amount)":17.021401676615067,"passenger_count":"0"},
{"COUNT(*)":1533197,"AVG(total_amount)":17.641883306799908,"passenger_count":"1"},
{"COUNT(*)":286461,"AVG(total_amount)":18.097587071145647,"passenger_count":"2"},
{"COUNT(*)":72852,"AVG(total_amount)":17.915395871092315,"passenger_count":"3"},
{"COUNT(*)":25510,"AVG(total_amount)":18.452774990196012,"passenger_count":"4"},
{"COUNT(*)":50291,"AVG(total_amount)":17.270924817567234,"passenger_count":"5"},
{"COUNT(*)":32623,"AVG(total_amount)":17.600296416636713,"passenger_count":"6"},
{"COUNT(*)":2,"AVG(total_amount)":87.17,"passenger_count":"7"},
{"COUNT(*)":2,"AVG(total_amount)":95.705,"passenger_count":"8"},
{"COUNT(*)":1,"AVG(total_amount)":113.6,"passenger_count":"9"}]
./dsq yellow_tripdata_2021-04.csv   83.04s user 4.22s system 210% cpu 41.356 total
```

for a standalone benchmark:

```
BENCHMARK=true go test -cpuprofile cpu.prof -bench . -run Test_sqlIngest
```