### PR TITLE
Increase debounce time, add flush on blur, ui tweaks

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -41,7 +41,7 @@ jobs:
         SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
         SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
         SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-    - run: cd runner && go test -coverprofile ../coverage/gounit.cov
+    - run: cd runner && go test -race -coverprofile ../coverage/gounit.cov
     - run: ./runner/scripts/test_coverage.sh
     # Test server builds
     - run: yarn build-server
@@ -135,7 +135,7 @@ jobs:
     # Needed so we can have ./build/desktop_runner.js ready for tests
     - run: yarn build-test-runner
     - run: yarn test --runInBand --detectOpenHandles --forceExit --verbose shared ui desktop
-    - run: cd runner && go test -cover
+    - run: cd runner && go test -race -cover
     - run: yarn release-desktop 0.0.0-e2etest
     - run: git reset --hard # release blows everything up
     - run: yarn e2e-test
@@ -166,7 +166,7 @@ jobs:
     # Needed so we can have ./build/desktop_runner.js ready for tests
     - run: yarn build-test-runner
     - run: yarn test --runInBand --detectOpenHandles --forceExit --verbose shared ui desktop
-    - run: cd runner && go test -cover
+    - run: cd runner && go test -race -cover
     - run: yarn release-desktop 0.0.0-e2etest
     - run: git reset --hard # release blows everything up
     - run: yarn e2e-test

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -134,8 +134,9 @@ jobs:
     - run: ./scripts/ci/prepare_macos.sh
     # Needed so we can have ./build/desktop_runner.js ready for tests
     - run: yarn build-test-runner
-    - run: yarn test --runInBand --detectOpenHandles --forceExit --verbose shared ui desktop
-    - run: cd runner && go test -race -cover
+    # https://github.com/golang/go/issues/49138 bug in macos -race detector
+    - run: MallocNanoZone=0 yarn test --runInBand --detectOpenHandles --forceExit --verbose shared ui desktop
+    - run: cd runner && MallocNanoZone=0 go test -race -cover
     - run: yarn release-desktop 0.0.0-e2etest
     - run: git reset --hard # release blows everything up
     - run: yarn e2e-test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,25 +33,14 @@ something to install all missing dependencies.
 
 ### ./desktop/panel
 
-NOTE: This code is being migrated to Go. All panel types except for a
-few database vendors have been ported to Go. A number of Node panel
-handlers have been deleted since they are no longer used.
-
-This is where eval handlers for each panel type (program, database,
-etc.) are defined.
-
-All database-specific handlers are defined in
-./desktop/panel/databases/*.ts since there are so many of them.
-
-Evaluation happens by spawning a Node.js subprocess where all the eval
-handlers are actually run. ./desktop/runner.ts is the entrypoint for
-this on desktop. ./server/runner.ts is the equivalent on the server.
-
-This allows easy resource cleanup and easy "kill" panel eval support.
+Evaluation happens by spawning a runner (see ./runner below)
+subprocess where all the eval handlers are actually run. This allows
+easy resource cleanup and easy "kill" panel eval support.
 
 ## ./runner
 
-This is where the Go port of the original Node.js panel eval code is.
+./runner/eval.go is the main eval entrypoint but the command line
+entrypoint is at ./runner/cmd/main.go.
 
 ## ./server
 
@@ -99,7 +88,20 @@ This is where types for all entities in state are described. Any time
 you want to add a new panel or connector, etc. you'll need to add it
 here.
 
+If the change needs to be read by the runner you'll also need to add
+the change to ./runner/state.go. There is nothing at the moment
+keeping these two files in sync other than tests that may exist.
+
 ### ./shared/languages
 
 This is where all supported languages are defined and where their
 libraries for interacting with DataStation are defined.
+
+The reason it's shared is because Python and JavaScript run in the
+browser in browser mode but on a machine in desktop/server mode.
+
+Language wrappers are defined in Jsonnet so that they can include
+comments and newlines. That is translated to JSON and embedded in Go
+with `yarn build-language-definitions`. The CI will complain if these
+definitions ever go out of date but it may be confusing locally not to
+see your changes until you run this and recompile the Go runner.

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -61,3 +61,8 @@ To re-run this process, use on Mac or Linux:
 ```
 $ yarn build-language-definitions
 ```
+
+## Tests blow up with SIGABRT on macos when -race is on
+
+See https://github.com/golang/go/issues/49138. Set `MallocNanoZone=0`
+before running tests to get around this.

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -1,6 +1,11 @@
+## yarn test vs yarn test-local
+
+The latter just doesn't involve running test coverage which takes
+longer and isn't that useful locally.
+
 ## Jest crashes with too many workers exception
 
-Run tests again with `--runInBand`: `yarn test --runInBand`.
+Run tests again with `--runInBand`: `yarn test-local --runInBand`.
 
 ## The packaged app is not starting, giving error messages
 
@@ -23,12 +28,12 @@ general.
 
 Should move to something that is not ts-jest eventually.
 
-## Run a single JavaScript test file
+## Run a single JavaScript test-local file
 
-Pass the test file name to `yarn test`.
+Pass the test-local file name to `yarn test`.
 
 ```bash
-yarn test server/exporter.test.js
+yarn test-local server/exporter.test.js
 ```
 
 ## Run tests on only a single runner type
@@ -41,7 +46,7 @@ tests against that runner will be run.
 For example:
 
 ```bash
-yarn test desktop/panel/file.test.js --dsrunner=memory
+yarn test-local desktop/panel/file.test.js --dsrunner=memory
 ```
 
 ## Adding/editing language libraries

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -66,3 +66,5 @@ $ yarn build-language-definitions
 
 See https://github.com/golang/go/issues/49138. Set `MallocNanoZone=0`
 before running tests to get around this.
+
+Or upgrade to a more recent minor version.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "e2e-test": "node --unhandled-rejections=throw ./e2e/index.js"
   },
   "dependencies": {
+    "@tabler/icons": "^1.53.0",
     "ace-builds": "^1.4.13",
     "chart.js": "^3.5.1",
     "cookie-parser": "^1.4.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format": "yarn prettier --write \"**/*.js\" \"**/*.test.js\" \"**/*.test.jsx\" \"**/*.ts\" \"**/*.tsx\" \"**/*.css\" \"**/*.json\"",
     "test-licenses": "yarn license-checker --production --onlyAllow 'Python-2.0;AFLv2.1;BSD;MIT;Apache-2.0;Apache 2.0;Apache*;ISC;BSD-3-Clause;MIT*;BSD-2-Clause;Unlicense'",
     "generate-test-data": "node --unhandled-rejections=strict ./scripts/generate_test_data.js",
-    "test": "jest --passWithNoTests --coverage",
+    "test": "yarn test-local --coverage",
+    "test-local": "jest --passWithNoTests",
     "e2e-test": "node --unhandled-rejections=throw ./e2e/index.js"
   },
   "dependencies": {

--- a/runner/scripts/runner_test.build
+++ b/runner/scripts/runner_test.build
@@ -1,3 +1,3 @@
 yarn esbuild desktop/runner.ts --bundle --platform=node --sourcemap --external:sqlite3 --external:react-native-fs --external:react-native-fetch-blob --external:oracledb "--external:@elastic/elasticsearch" "--external:wasm-brotli" --external:prometheus-query --external:snowflake-sdk --external:ssh2 --external:ssh2-promise --external:ssh2-sftp-client --external:cpu-features --external:electron --external:pg-native --target=node10.4 --outfile=build/desktop_runner.js
 
-cd runner/cmd && go test -o ../../build/go_desktop_runner_test{required_ext} -coverpkg="." -c -tags testrunmain
+cd runner/cmd && go test -race -o ../../build/go_desktop_runner_test{required_ext} -coverpkg="." -c -tags testrunmain

--- a/runner/ssh.go
+++ b/runner/ssh.go
@@ -203,6 +203,54 @@ fi`, remoteFileName, remoteFileName)
 	return nil
 }
 
+// SOURCE: https://www.stavros.io/posts/proxying-two-connections-go/
+func chanFromConn(conn net.Conn) chan []byte {
+	c := make(chan []byte)
+
+	go func() {
+		b := make([]byte, 1024)
+
+		for {
+			n, err := conn.Read(b)
+			if n > 0 {
+				res := make([]byte, n)
+				// Copy the buffer so it doesn't get changed while read by the recipient.
+				copy(res, b[:n])
+				c <- res
+			}
+			if err != nil {
+				c <- nil
+				break
+			}
+		}
+	}()
+
+	return c
+}
+
+// SOURCE: https://www.stavros.io/posts/proxying-two-connections-go/
+func pipe(conn1 net.Conn, conn2 net.Conn) {
+	chan1 := chanFromConn(conn1)
+	chan2 := chanFromConn(conn2)
+
+	for {
+		select {
+		case b1 := <-chan1:
+			if b1 == nil {
+				return
+			} else {
+				conn2.Write(b1)
+			}
+		case b2 := <-chan2:
+			if b2 == nil {
+				return
+			} else {
+				conn1.Write(b2)
+			}
+		}
+	}
+}
+
 func withRemoteConnection(si *ServerInfo, host, port string, cb func(host, port string) error) error {
 	if si == nil {
 		return cb(host, port)
@@ -236,19 +284,7 @@ func withRemoteConnection(si *ServerInfo, host, port string, cb func(host, port 
 			return
 		}
 
-		go func() {
-			_, err = io.Copy(remoteConn, localConn)
-			if errC != nil {
-				errC <- err
-			}
-
-		}()
-
-		// Remote server
-		go func() {
-			_, err = io.Copy(localConn, remoteConn)
-			errC <- err
-		}()
+		pipe(localConn, remoteConn)
 	}()
 
 	localPort := localConn.Addr().(*net.TCPAddr).Port

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -5,17 +5,10 @@ export const CHAT_LINK = 'https://discord.gg/f2wQBc4bXX';
 export const RPC_ASYNC_REQUEST = 'rpcAsyncRequest';
 export const RPC_ASYNC_RESPONSE = 'rpcAsyncResponse';
 
-let wg;
-try {
-  wg = window as any;
-} catch (e) {
-  wg = global as any;
-}
-
 function getConfig<T>(v: string, _default: T) {
   const key = 'DS_CONFIG_' + v;
-  if (key in wg) {
-    return wg[key] as T;
+  if (key in globalThis) {
+    return (globalThis as any)[key] as T;
   }
 
   return _default;
@@ -44,6 +37,6 @@ export const MODE_FEATURES = {
 const DOCS_VERSION = VERSION === 'development' ? 'latest' : VERSION;
 export const DOCS_ROOT = SITE_ROOT + '/docs/' + DOCS_VERSION;
 
-export const IN_TESTS = wg.process
+export const IN_TESTS = globalThis.process
   ? process.env.JEST_WORKER_ID !== undefined
   : false;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -43,4 +43,4 @@ export const MODE_FEATURES = {
 const DOCS_VERSION = VERSION === 'development' ? 'latest' : VERSION;
 export const DOCS_ROOT = SITE_ROOT + '/docs/' + DOCS_VERSION;
 
-export const IN_TESTS = process.env.JEST_WORKER_ID !== undefined;
+export const IN_TESTS = window.process ? process.env.JEST_WORKER_ID !== undefined : false;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -43,4 +43,6 @@ export const MODE_FEATURES = {
 const DOCS_VERSION = VERSION === 'development' ? 'latest' : VERSION;
 export const DOCS_ROOT = SITE_ROOT + '/docs/' + DOCS_VERSION;
 
-export const IN_TESTS = window.process ? process.env.JEST_WORKER_ID !== undefined : false;
+export const IN_TESTS = window.process
+  ? process.env.JEST_WORKER_ID !== undefined
+  : false;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -5,14 +5,15 @@ export const CHAT_LINK = 'https://discord.gg/f2wQBc4bXX';
 export const RPC_ASYNC_REQUEST = 'rpcAsyncRequest';
 export const RPC_ASYNC_RESPONSE = 'rpcAsyncResponse';
 
+let wg;
+try {
+  wg = window as any;
+} catch (e) {
+  wg = global as any;
+}
+
 function getConfig<T>(v: string, _default: T) {
   const key = 'DS_CONFIG_' + v;
-  let wg;
-  try {
-    wg = window as any;
-  } catch (e) {
-    wg = global as any;
-  }
   if (key in wg) {
     return wg[key] as T;
   }
@@ -43,6 +44,6 @@ export const MODE_FEATURES = {
 const DOCS_VERSION = VERSION === 'development' ? 'latest' : VERSION;
 export const DOCS_ROOT = SITE_ROOT + '/docs/' + DOCS_VERSION;
 
-export const IN_TESTS = window.process
+export const IN_TESTS = wg.process
   ? process.env.JEST_WORKER_ID !== undefined
   : false;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -42,3 +42,5 @@ export const MODE_FEATURES = {
 // There is no /docs/development/ so replace it with /docs/latest/
 const DOCS_VERSION = VERSION === 'development' ? 'latest' : VERSION;
 export const DOCS_ROOT = SITE_ROOT + '/docs/' + DOCS_VERSION;
+
+export const IN_TESTS = process.env.JEST_WORKER_ID !== undefined;

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -321,7 +321,7 @@ export interface GraphField {
 
 export type GraphPanelInfoType = 'bar' | 'pie' | 'line';
 
-export type GraphPanelInfoWidth = 'small' | 'medium' | 'large';
+export type PanelInfoWidth = 'small' | 'medium' | 'large';
 
 export class GraphPanelInfo extends PanelInfo {
   graph: {
@@ -329,7 +329,7 @@ export class GraphPanelInfo extends PanelInfo {
     ys: Array<GraphField>;
     x: string;
     type: GraphPanelInfoType;
-    width: GraphPanelInfoWidth;
+    width: PanelInfoWidth;
     colors: {
       unique: boolean;
     };
@@ -455,6 +455,7 @@ export class TablePanelInfo extends PanelInfo {
   table: {
     columns: Array<TableColumn>;
     panelSource: string;
+    width: PanelInfoWidth;
   };
 
   constructor(
@@ -466,6 +467,7 @@ export class TablePanelInfo extends PanelInfo {
     this.table = {
       columns: defaults.columns || [],
       panelSource: defaults.panelSource || '',
+      width: defaults.width || 'small',
     };
   }
 }

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -456,6 +456,7 @@ export class TablePanelInfo extends PanelInfo {
     columns: Array<TableColumn>;
     panelSource: string;
     width: PanelInfoWidth;
+    rowNumbers: boolean;
   };
 
   constructor(
@@ -468,6 +469,7 @@ export class TablePanelInfo extends PanelInfo {
       columns: defaults.columns || [],
       panelSource: defaults.panelSource || '',
       width: defaults.width || 'small',
+      rowNumbers: defaults.rowNumbers || true,
     };
   }
 }

--- a/shared/table.ts
+++ b/shared/table.ts
@@ -1,4 +1,5 @@
 import { NotAnArrayOfObjectsError } from './errors';
+import { getPath } from './object';
 
 export function columnsFromObject(
   value: any,
@@ -21,7 +22,7 @@ export function columnsFromObject(
 
     const cells: Record<string, any> = {};
     (columns || []).forEach((name) => {
-      cells[name] = row[name];
+      cells[name] = getPath(row, name);
     });
     return cells;
   });

--- a/testsetup.js
+++ b/testsetup.js
@@ -14,6 +14,14 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>', {
 });
 const { window } = jsdom;
 
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+window.ResizeObserver = ResizeObserver;
+
 function copyProps(src, target) {
   Object.defineProperties(target, {
     ...Object.getOwnPropertyDescriptors(src),

--- a/ui/Connector.tsx
+++ b/ui/Connector.tsx
@@ -1,3 +1,4 @@
+import { IconTrash } from '@tabler/icons';
 import * as React from 'react';
 import { ConnectorInfo, DatabaseConnectorInfo } from '../shared/state';
 import { Button } from './components/Button';
@@ -50,7 +51,7 @@ export function Connector({
               action="Delete"
               render={(confirm: () => void) => (
                 <Button icon onClick={confirm} type="outline">
-                  delete
+                  <IconTrash />
                 </Button>
               )}
             />

--- a/ui/Connector.tsx
+++ b/ui/Connector.tsx
@@ -1,4 +1,4 @@
-import { IconTrash } from '@tabler/icons';
+import { IconPencil, IconTrash } from '@tabler/icons';
 import * as React from 'react';
 import { ConnectorInfo, DatabaseConnectorInfo } from '../shared/state';
 import { Button } from './components/Button';
@@ -41,7 +41,7 @@ export function Connector({
               onClick={() => setExpanded(true)}
               title="Edit"
             >
-              edit
+              <IconPencil />
             </Button>
           )}
           <span title="Delete data source">

--- a/ui/Header.tsx
+++ b/ui/Header.tsx
@@ -1,3 +1,4 @@
+import { IconMenu2 } from '@tabler/icons';
 import * as React from 'react';
 import { APP_NAME, MODE } from '../shared/constants';
 import '../shared/polyfill';
@@ -63,7 +64,7 @@ export function Header() {
                   toggleDropdown((open) => !open);
                 }}
               >
-                menu
+                <IconMenu2 />
               </Button>
             </div>
             <div className="global-dropdown-body">

--- a/ui/Header.tsx
+++ b/ui/Header.tsx
@@ -86,7 +86,7 @@ export function Header() {
                   </div>
                   <div className="global-dropdown-item">
                     <Link args={{ projectId, view: 'settings', page: 0 }}>
-                      See All
+                      All Settings
                     </Link>
                   </div>
                 </div>

--- a/ui/PageList.tsx
+++ b/ui/PageList.tsx
@@ -1,3 +1,4 @@
+import { IconTrash } from '@tabler/icons';
 import * as React from 'react';
 import { MODE_FEATURES } from '../shared/constants';
 import { EVAL_ERRORS } from '../shared/errors';
@@ -182,8 +183,8 @@ export function PageList({
                   action="Delete"
                   className="page-delete"
                   render={(confirm: () => void) => (
-                    <Button icon onClick={confirm} type="outline">
-                      delete
+                    <Button icon onClick={confirm}>
+                      <IconTrash />
                     </Button>
                   )}
                 />

--- a/ui/PageList.tsx
+++ b/ui/PageList.tsx
@@ -195,7 +195,6 @@ export function PageList({
                   page.name = value;
                   updatePage(page);
                 }}
-                autoWidth
                 value={page.name}
               />
 

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -1,6 +1,7 @@
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import circularSafeStringify from 'json-stringify-safe';
+import { UrlStateContext } from './urlState';
 import * as CSV from 'papaparse';
 import * as React from 'react';
 import { toString } from 'shape';
@@ -232,6 +233,11 @@ export function Panel({
   const [details, setDetails] = React.useState(isBlank);
   const [hidden, setHidden] = React.useState(false);
 
+  const {
+    state: { fullScreen },
+    setState: setUrlState,
+  } = React.useContext(UrlStateContext);
+
   const [panelOut, setPanelOut] = React.useState<
     'preview' | 'stdout' | 'shape' | 'metadata'
   >('preview');
@@ -279,7 +285,7 @@ export function Panel({
   return (
     <div
       id={`panel-${panel.id}`}
-      className={`panel ${hidden ? 'panel--hidden' : ''} ${
+      className={`panel ${fullScreen === panel.id ? 'panel--fullscreen' : ''} ${hidden ? 'panel--hidden' : ''} ${
         panelUIDetails.body === null && !results.exception ? 'panel--empty' : ''
       } ${results.loading ? 'panel--loading' : ''}`}
       tabIndex={1001}
@@ -412,6 +418,11 @@ export function Panel({
                   {results.loading ? 'close' : 'play_arrow'}
                 </Button>
               </span>
+              <span title="Full screen mode">
+                <Button icon onClick={() => setUrlState({ fullScreen: fullScreen === panel.id ? null : panel.id})} disabled={hidden}>
+                  {fullScreen === panel.id ? 'close_fullscreen' : 'open_in_full'}
+                </Button>
+              </span>
               <span
                 title={
                   !results.lastRun ? 'Panel not yet run' : 'Download Results'
@@ -498,7 +509,7 @@ export function Panel({
                         className={panelOut === 'preview' ? 'selected' : ''}
                         onClick={() => setPanelOut('preview')}
                       >
-                        Preview
+                        Result
                       </Button>
                       <Button
                         className={panelOut === 'shape' ? 'selected' : ''}

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -1,3 +1,16 @@
+import {
+  IconArrowsDiagonal,
+  IconArrowsDiagonalMinimize2,
+  IconChevronDown,
+  IconChevronUp,
+  IconDotsVertical,
+  IconDownload,
+  IconEye,
+  IconEyeOff,
+  IconPlayerPause,
+  IconPlayerPlay,
+  IconTrash,
+} from '@tabler/icons';
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import circularSafeStringify from 'json-stringify-safe';
@@ -320,7 +333,7 @@ export function Panel({
                   movePanel(panelIndex, panelIndex - 1);
                 }}
               >
-                keyboard_arrow_up
+                <IconChevronUp />
               </Button>
             </span>
             <span title="Move Down">
@@ -331,7 +344,7 @@ export function Panel({
                   movePanel(panelIndex, panelIndex + 1);
                 }}
               >
-                keyboard_arrow_down
+                <IconChevronDown />
               </Button>
             </span>
             <Select
@@ -378,7 +391,7 @@ export function Panel({
                 icon
                 onClick={() => setDetails(!details)}
               >
-                {details ? 'menu_open' : 'menu'}
+                <IconDotsVertical />
               </Button>
             </span>
 
@@ -428,7 +441,7 @@ export function Panel({
                   }
                   type="primary"
                 >
-                  {results.loading ? 'close' : 'play_arrow'}
+                  {results.loading ? <IconPlayerPause /> : <IconPlayerPlay />}
                 </Button>
               </span>
               <span title="Full screen mode">
@@ -441,9 +454,11 @@ export function Panel({
                   }
                   disabled={hidden}
                 >
-                  {fullScreen === panel.id
-                    ? 'close_fullscreen'
-                    : 'open_in_full'}
+                  {fullScreen === panel.id ? (
+                    <IconArrowsDiagonalMinimize2 />
+                  ) : (
+                    <IconArrowsDiagonal />
+                  )}
                 </Button>
               </span>
               <span
@@ -458,12 +473,12 @@ export function Panel({
                     fetchAndDownloadResults(panel, panelRef, results)
                   }
                 >
-                  file_download
+                  <IconDownload />
                 </Button>
               </span>
               <span title="Hide Panel">
                 <Button icon onClick={() => setHidden(!hidden)}>
-                  {hidden ? 'visibility' : 'visibility_off'}
+                  {hidden ? <IconEye /> : <IconEyeOff />}
                 </Button>
               </span>
               <span title="Delete Panel">
@@ -473,7 +488,7 @@ export function Panel({
                   action="Delete"
                   render={(confirm: () => void) => (
                     <Button icon onClick={confirm} type="outline">
-                      delete
+                      <IconTrash />
                     </Button>
                   )}
                 />

--- a/ui/Panel.tsx
+++ b/ui/Panel.tsx
@@ -375,7 +375,6 @@ export function Panel({
             <Input
               label="Name"
               className="panel-name"
-              autoWidth
               placeholder={`Untitled panel #${panels.length + 1}`}
               onChange={(value: string) => {
                 panel.name = value;

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -1,9 +1,11 @@
+import { IconChartBar, IconTable } from '@tabler/icons';
 import * as React from 'react';
 import {
   PanelInfo,
   PanelResultMeta,
   ProgramPanelInfo,
   ProjectPage,
+  TablePanelInfo,
 } from '../shared/state';
 import { Button } from './components/Button';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -45,6 +47,25 @@ export function PanelList({
   }
 
   function newPanel(panelIndex: number) {
+    const panel = page.panels[panelIndex];
+
+    function makePanel(type: string, prefix: string) {
+      const next = new TablePanelInfo({
+        name: prefix + ' ' + panel.name,
+        panelSource: panel.id,
+      });
+      page.panels.splice(panelIndex + 1, 0, next);
+      updatePage(page);
+    }
+
+    const offerToGraph =
+      panel &&
+      !['graph', 'table'].includes(panel.type) &&
+      panel.resultMeta &&
+      panel.resultMeta.shape &&
+      panel.resultMeta.shape.kind === 'array' &&
+      panel.resultMeta.shape.children.kind === 'object';
+
     return (
       <div className="new-panel">
         <Button
@@ -71,6 +92,20 @@ export function PanelList({
         >
           Add Panel
         </Button>
+        {offerToGraph ? (
+          <React.Fragment>
+            <span title="Generate a graph for the above panel">
+              <Button onClick={() => makePanel('graph', 'Graph of ')} icon>
+                <IconChartBar />
+              </Button>
+            </span>
+            <span title="Generate a table for the above panel">
+              <Button onClick={() => makePanel('table', 'Data from')} icon>
+                <IconTable />
+              </Button>
+            </span>
+          </React.Fragment>
+        ) : null}
       </div>
     );
   }

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -99,7 +99,7 @@ export function PanelList({
       page.panels.splice(panelIndex + 1, 0, next);
       updatePage(page);
       // Give time for write before evalling
-      setTimeout(    () =>  reevalPanel(next.id), 1000);
+      setTimeout(    () =>  reevalPanel(next.id), 300);
     }
 
     const offerToTable =

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from './components/Button';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Panel } from './Panel';
+import { PANEL_GROUPS, PANEL_UI_DETAILS } from './panels';
 
 export function PanelList({
   page,
@@ -54,6 +55,18 @@ export function PanelList({
             page.panels.splice(panelIndex + 1, 0, panel);
             updatePage(page);
           }}
+          options={PANEL_GROUPS.map((group) => (
+                <optgroup label={group.label} key={group.label}>
+                  {group.panels.map((name) => {
+                    const panelDetails = PANEL_UI_DETAILS[name];
+                    return (
+                      <option value={panelDetails.id} key={panelDetails.id}>
+                        {panelDetails.label}
+                      </option>
+                    );
+                  })}
+                </optgroup>
+              ))}
         >
           Add Panel
         </Button>

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -99,7 +99,7 @@ export function PanelList({
       page.panels.splice(panelIndex + 1, 0, next);
       updatePage(page);
       // Give time for write before evalling
-      setTimeout(    () =>  reevalPanel(next.id), 300);
+      setTimeout(() => reevalPanel(next.id), 300);
     }
 
     const offerToTable =

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { UrlStateContext } from './urlState';
 import {
   PanelInfo,
   PanelResultMeta,
@@ -72,6 +73,26 @@ export function PanelList({
         </Button>
       </div>
     );
+  }
+
+  
+  const {
+    state: { fullScreen },
+  } = React.useContext(UrlStateContext);
+  const fullScreenIndex = fullScreen ? page.panels.findIndex(p => p.id === fullScreen) : null;
+  if (typeof fullScreenIndex === 'number' && fullScreenIndex >= 0) {
+    const panel = page.panels[fullScreenIndex];
+    return <Panel
+            panel={panel}
+            updatePanel={updatePanel(page, panel.id)}
+            panelResults={panelResults}
+            reevalPanel={reevalPanel}
+            panelIndex={fullScreenIndex}
+            movePanel={movePanel}
+            removePanel={removePanel}
+            panels={page.panels}
+    />
+    ;
   }
 
   return (

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { UrlStateContext } from './urlState';
 import {
   PanelInfo,
   PanelResultMeta,
@@ -10,6 +9,7 @@ import { Button } from './components/Button';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Panel } from './Panel';
 import { PANEL_GROUPS, PANEL_UI_DETAILS } from './panels';
+import { UrlStateContext } from './urlState';
 
 export function PanelList({
   page,
@@ -57,17 +57,17 @@ export function PanelList({
             updatePage(page);
           }}
           options={PANEL_GROUPS.map((group) => (
-                <optgroup label={group.label} key={group.label}>
-                  {group.panels.map((name) => {
-                    const panelDetails = PANEL_UI_DETAILS[name];
-                    return (
-                      <option value={panelDetails.id} key={panelDetails.id}>
-                        {panelDetails.label}
-                      </option>
-                    );
-                  })}
-                </optgroup>
-              ))}
+            <optgroup label={group.label} key={group.label}>
+              {group.panels.map((name) => {
+                const panelDetails = PANEL_UI_DETAILS[name];
+                return (
+                  <option value={panelDetails.id} key={panelDetails.id}>
+                    {panelDetails.label}
+                  </option>
+                );
+              })}
+            </optgroup>
+          ))}
         >
           Add Panel
         </Button>
@@ -75,24 +75,26 @@ export function PanelList({
     );
   }
 
-  
   const {
     state: { fullScreen },
   } = React.useContext(UrlStateContext);
-  const fullScreenIndex = fullScreen ? page.panels.findIndex(p => p.id === fullScreen) : null;
+  const fullScreenIndex = fullScreen
+    ? page.panels.findIndex((p) => p.id === fullScreen)
+    : null;
   if (typeof fullScreenIndex === 'number' && fullScreenIndex >= 0) {
     const panel = page.panels[fullScreenIndex];
-    return <Panel
-            panel={panel}
-            updatePanel={updatePanel(page, panel.id)}
-            panelResults={panelResults}
-            reevalPanel={reevalPanel}
-            panelIndex={fullScreenIndex}
-            movePanel={movePanel}
-            removePanel={removePanel}
-            panels={page.panels}
-    />
-    ;
+    return (
+      <Panel
+        panel={panel}
+        updatePanel={updatePanel(page, panel.id)}
+        panelResults={panelResults}
+        reevalPanel={reevalPanel}
+        panelIndex={fullScreenIndex}
+        movePanel={movePanel}
+        removePanel={removePanel}
+        panels={page.panels}
+      />
+    );
   }
 
   return (

--- a/ui/PanelList.tsx
+++ b/ui/PanelList.tsx
@@ -36,8 +36,6 @@ export function PanelList({
     page.panels.splice(from, 1);
     page.panels.splice(to, 0, panel);
     updatePage(page);
-    reevalPanel(page.panels[from].id, true);
-    reevalPanel(page.panels[to].id, true);
   }
 
   function removePanel(at: number) {
@@ -100,7 +98,8 @@ export function PanelList({
 
       page.panels.splice(panelIndex + 1, 0, next);
       updatePage(page);
-      reevalPanel(next.id);
+      // Give time for write before evalling
+      setTimeout(    () =>  reevalPanel(next.id), 1000);
     }
 
     const offerToTable =

--- a/ui/Server.tsx
+++ b/ui/Server.tsx
@@ -1,3 +1,4 @@
+import { IconTrash } from '@tabler/icons';
 import * as React from 'react';
 import { MODE } from '../shared/constants';
 import { ServerInfo, ServerInfoType } from '../shared/state';
@@ -74,7 +75,7 @@ export function Server({
               render={function renderDelete(confirm: () => void) {
                 return (
                   <Button icon onClick={confirm} type="outline">
-                    delete
+                    <IconTrash />
                   </Button>
                 );
               }}

--- a/ui/Server.tsx
+++ b/ui/Server.tsx
@@ -1,4 +1,4 @@
-import { IconTrash } from '@tabler/icons';
+import { IconPencil, IconTrash } from '@tabler/icons';
 import * as React from 'react';
 import { MODE } from '../shared/constants';
 import { ServerInfo, ServerInfoType } from '../shared/state';
@@ -64,7 +64,7 @@ export function Server({
               }}
               title="Edit"
             >
-              edit
+              <IconPencil />
             </Button>
           )}
           <span title="Delete server">

--- a/ui/Sidebar.tsx
+++ b/ui/Sidebar.tsx
@@ -1,9 +1,17 @@
 import { IconChevronLeft, IconChevronRight, IconSearch } from '@tabler/icons';
 import * as React from 'react';
 import { Button } from './components/Button';
+import { UrlStateContext } from './urlState';
 
 export function Sidebar({ children }: { children: React.ReactNode }) {
-  const [expanded, setExpanded] = React.useState(true);
+  const {
+    state: { sidebar: expanded },
+    setState: setUrlState,
+  } = React.useContext(UrlStateContext);
+
+  function setExpanded(v: boolean) {
+    setUrlState({ sidebar: v });
+  }
 
   return (
     <div className={`section sidebar ${!expanded ? 'sidebar--collapsed' : ''}`}>

--- a/ui/Sidebar.tsx
+++ b/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { IconChevronLeft, IconChevronRight, IconSearch } from '@tabler/icons';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
 import * as React from 'react';
 import { Button } from './components/Button';
 import { UrlStateContext } from './urlState';
@@ -16,7 +16,6 @@ export function Sidebar({ children }: { children: React.ReactNode }) {
   return (
     <div className={`section sidebar ${!expanded ? 'sidebar--collapsed' : ''}`}>
       <div className="title vertical-align-center">
-        <IconSearch height={18} width={18} />
         <Button
           icon
           className="flex-right"

--- a/ui/Sidebar.tsx
+++ b/ui/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { IconChevronLeft, IconChevronRight, IconSearch } from '@tabler/icons';
 import * as React from 'react';
 import { Button } from './components/Button';
 
@@ -7,7 +8,7 @@ export function Sidebar({ children }: { children: React.ReactNode }) {
   return (
     <div className={`section sidebar ${!expanded ? 'sidebar--collapsed' : ''}`}>
       <div className="title vertical-align-center">
-        <span className="material-icons-outlined">manage_search</span>
+        <IconSearch height={18} width={18} />
         <Button
           icon
           className="flex-right"
@@ -15,7 +16,7 @@ export function Sidebar({ children }: { children: React.ReactNode }) {
             return setExpanded(!expanded);
           }}
         >
-          {expanded ? 'keyboard_arrow_left' : 'keyboard_arrow_right'}
+          {expanded ? <IconChevronLeft /> : <IconChevronRight />}
         </Button>
       </div>
       {expanded && children}

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -30,7 +30,7 @@ if (MODE === 'browser') {
       // These can be really big, so run it out of band
       setTimeout(function () {
         l.inMemoryInit();
-      }, 0);
+      });
     }
   });
 }

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -45,7 +45,7 @@ function useProjectState(
     function setState(newState: ProjectState, addToRestoreBuffer = true) {
       // Don't hang renderer while updating
       setTimeout(function () {
-	store.update(projectId, newState, addToRestoreBuffer)
+        store.update(projectId, newState, addToRestoreBuffer);
       }, 0);
       const c = { ...newState };
       Object.setPrototypeOf(c, ProjectState.prototype);

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -43,7 +43,10 @@ function useProjectState(
 
   const setState = React.useCallback(
     function setState(newState: ProjectState, addToRestoreBuffer = true) {
-      store.update(projectId, newState, addToRestoreBuffer);
+      // Don't hang renderer while updating
+      setTimeout(function () {
+	store.update(projectId, newState, addToRestoreBuffer)
+      }, 0);
       const c = { ...newState };
       Object.setPrototypeOf(c, ProjectState.prototype);
       setProjectState(c);

--- a/ui/components/Alert.tsx
+++ b/ui/components/Alert.tsx
@@ -1,3 +1,9 @@
+import {
+  IconAlertTriangle,
+  IconBug,
+  IconHeartbeat,
+  IconInfoCircle,
+} from '@tabler/icons';
 import * as React from 'react';
 
 type AlertTypes = 'fatal' | 'error' | 'warning' | 'info';
@@ -9,16 +15,17 @@ export function Alert({
   type: AlertTypes;
   children: React.ReactNode;
 }) {
-  const icon =
-    (
-      {
-        error: 'new_releases',
-        fatal: 'bug_report',
-      } as Record<AlertTypes, string>
-    )[type] || type;
+  const icon = (
+    {
+      info: <IconInfoCircle />,
+      warning: <IconAlertTriangle />,
+      error: <IconBug />,
+      fatal: <IconHeartbeat />,
+    } as Record<AlertTypes, React.ReactNode>
+  )[type];
   return (
     <div className={`vertical-align-center alert alert-${type}`}>
-      <span className="material-icons" children={icon} />
+      {icon}
       <div>{children}</div>
     </div>
   );

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -14,7 +14,7 @@ export function Button({ className, type, icon, ...props }: ButtonProps) {
   }
 
   if (icon) {
-    buttonClass += ' material-icons' + (type === 'outline' ? '-outlined' : '');
+    buttonClass += ' button--icon';
   }
 
   return <button type="button" className={buttonClass} {...props} />;

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 export interface ButtonProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: 'primary' | 'outline';
-    icon?: boolean;
-    options?: React.ReactNode;
+  icon?: boolean;
+  options?: React.ReactNode;
 }
 
 export function Button({ className, type, icon, ...props }: ButtonProps) {

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 export interface ButtonProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: 'primary' | 'outline';
-  icon?: boolean;
+    icon?: boolean;
+    options?: React.ReactNode;
 }
 
 export function Button({ className, type, icon, ...props }: ButtonProps) {

--- a/ui/components/CodeEditor.tsx
+++ b/ui/components/CodeEditor.tsx
@@ -50,7 +50,10 @@ export function CodeEditor({
   const {
     state: { theme },
   } = React.useContext(SettingsContext);
-  const [localValue, setLocalValue, flushLocalValue] = useDebouncedLocalState(value, onChange);
+  const [localValue, setLocalValue, flushLocalValue] = useDebouncedLocalState(
+    value,
+    onChange
+  );
 
   return (
     <div
@@ -63,8 +66,8 @@ export function CodeEditor({
         mode={language}
         theme={theme === 'dark' ? 'dracula' : 'github'}
         maxLines={singleLine ? 1 : undefined}
-    onChange={setLocalValue}
-    onBlur={flushLocalValue}
+        onChange={setLocalValue}
+        onBlur={flushLocalValue}
         name={id}
         value={String(localValue)}
         placeholder={placeholder}
@@ -83,12 +86,15 @@ export function CodeEditor({
             name: 'ctrl-enter',
             bindKey: { win: 'Ctrl-Enter', mac: 'Ctrl-Enter' },
             exec: () => {
-	      flushLocalValue();
-              return onKeyDown({
-                ctrlKey: true,
-                code: 'Enter',
-              } as React.KeyboardEvent);
-	    },
+              flushLocalValue();
+              // Give time to flush
+              return setTimeout(() =>
+                onKeyDown({
+                  ctrlKey: true,
+                  code: 'Enter',
+                } as React.KeyboardEvent)
+              );
+            },
           },
           singleLine
             ? {

--- a/ui/components/CodeEditor.tsx
+++ b/ui/components/CodeEditor.tsx
@@ -55,6 +55,22 @@ export function CodeEditor({
     onChange
   );
 
+  const editor = React.useRef(null);
+
+  // Make sure editor resizes if the overall panel changes size. For
+  // example this happens when the preview height changes.
+  React.useEffect(() => {
+    if (editor.current) {
+      const panel = editor.current.editor.container.closest('.panel');
+      const obs = new ResizeObserver(function handleEditorResize() {
+        editor.current.editor.resize();
+      });
+      obs.observe(panel);
+
+      return () => obs.disconnect();
+    }
+  }, [editor.current]);
+
   return (
     <div
       className={`editor-container ${
@@ -63,9 +79,11 @@ export function CodeEditor({
     >
       {label && <label className="label input-label">{label}</label>}
       <AceEditor
+        ref={r => editor.current = r}
         mode={language}
         theme={theme === 'dark' ? 'dracula' : 'github'}
         maxLines={singleLine ? 1 : undefined}
+      wrapEnabled={true}
         onChange={setLocalValue}
         onBlur={flushLocalValue}
         name={id}

--- a/ui/components/CodeEditor.tsx
+++ b/ui/components/CodeEditor.tsx
@@ -50,7 +50,7 @@ export function CodeEditor({
   const {
     state: { theme },
   } = React.useContext(SettingsContext);
-  const [localValue, setLocalValue] = useDebouncedLocalState(value, onChange);
+  const [localValue, setLocalValue, flushLocalValue] = useDebouncedLocalState(value, onChange);
 
   return (
     <div
@@ -63,7 +63,8 @@ export function CodeEditor({
         mode={language}
         theme={theme === 'dark' ? 'dracula' : 'github'}
         maxLines={singleLine ? 1 : undefined}
-        onChange={setLocalValue}
+    onChange={setLocalValue}
+    onBlur={flushLocalValue}
         name={id}
         value={String(localValue)}
         placeholder={placeholder}
@@ -81,11 +82,13 @@ export function CodeEditor({
           {
             name: 'ctrl-enter',
             bindKey: { win: 'Ctrl-Enter', mac: 'Ctrl-Enter' },
-            exec: () =>
-              onKeyDown({
+            exec: () => {
+	      flushLocalValue();
+              return onKeyDown({
                 ctrlKey: true,
                 code: 'Enter',
-              } as React.KeyboardEvent),
+              } as React.KeyboardEvent);
+	    },
           },
           singleLine
             ? {

--- a/ui/components/CodeEditor.tsx
+++ b/ui/components/CodeEditor.tsx
@@ -79,11 +79,11 @@ export function CodeEditor({
     >
       {label && <label className="label input-label">{label}</label>}
       <AceEditor
-        ref={r => editor.current = r}
+        ref={(r) => (editor.current = r)}
         mode={language}
         theme={theme === 'dark' ? 'dracula' : 'github'}
         maxLines={singleLine ? 1 : undefined}
-      wrapEnabled={true}
+        wrapEnabled={true}
         onChange={setLocalValue}
         onBlur={flushLocalValue}
         name={id}

--- a/ui/components/FieldPicker.test.jsx
+++ b/ui/components/FieldPicker.test.jsx
@@ -5,6 +5,7 @@ const sample1 = shape({
   a: '1',
   x: 1,
   z: '1',
+  c: { t: 100, n: { b: 'Kevin' } },
   // Non-scalar anything
   d: {},
 });
@@ -15,16 +16,16 @@ test('orderedObjectFields preferring string', () => {
       name: 'String',
       elements: [
         ['a', { kind: 'scalar', name: 'string' }],
+        ['c.n.b', { kind: 'scalar', name: 'string' }],
         ['z', { kind: 'scalar', name: 'string' }],
       ],
     },
     {
       name: 'Number',
-      elements: [['x', { kind: 'scalar', name: 'number' }]],
-    },
-    {
-      name: 'Other',
-      elements: [['d', { kind: 'object', children: {} }]],
+      elements: [
+        ['c.t', { kind: 'scalar', name: 'number' }],
+        ['x', { kind: 'scalar', name: 'number' }],
+      ],
     },
   ]);
 });
@@ -33,18 +34,18 @@ test('orderedObjectFields preferring number', () => {
   expect(orderedObjectFields(sample1, 'number')).toStrictEqual([
     {
       name: 'Number',
-      elements: [['x', { kind: 'scalar', name: 'number' }]],
+      elements: [
+        ['c.t', { kind: 'scalar', name: 'number' }],
+        ['x', { kind: 'scalar', name: 'number' }],
+      ],
     },
     {
       name: 'String',
       elements: [
         ['a', { kind: 'scalar', name: 'string' }],
+        ['c.n.b', { kind: 'scalar', name: 'string' }],
         ['z', { kind: 'scalar', name: 'string' }],
       ],
-    },
-    {
-      name: 'Other',
-      elements: [['d', { kind: 'object', children: {} }]],
     },
   ]);
 });

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -1,7 +1,7 @@
 import debounce from 'lodash.debounce';
 import * as React from 'react';
-import { Tooltip } from './Tooltip';
 import { IN_TESTS } from '../../shared/constants';
+import { Tooltip } from './Tooltip';
 
 export const INPUT_SYNC_PERIOD = IN_TESTS ? 0 : 3000;
 

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -105,7 +105,7 @@ export function Input({
           setLocalValue(String(e.target.value))
         }
         {...props}
-        size={autoWidth ? Math.min(100, String(localValue).length) : undefined}
+        size={autoWidth ? Math.max(20, String(localValue).length) : undefined}
       />
       {tooltip && <Tooltip children={tooltip} />}
       {invalid && <small className="input-invalid">{invalid}</small>}

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -39,7 +39,6 @@ export function useDebouncedLocalState(
   }
 
   function flushValue() {
-    console.log('flushing', debounced.flush);
     debounced.flush();
   }
 

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -1,8 +1,9 @@
 import debounce from 'lodash.debounce';
 import * as React from 'react';
 import { Tooltip } from './Tooltip';
+import { IN_TESTS } from '../../shared/constants';
 
-export const INPUT_SYNC_PERIOD = 3000;
+export const INPUT_SYNC_PERIOD = IN_TESTS ? 0 : 3000;
 
 export function useDebouncedLocalState(
   nonLocalValue: string | number | readonly string[],

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 import * as React from 'react';
 import { Tooltip } from './Tooltip';
 
-export const INPUT_SYNC_PERIOD = 125;
+export const INPUT_SYNC_PERIOD = 3000;
 
 export function useDebouncedLocalState(
   nonLocalValue: string | number | readonly string[],

--- a/ui/components/ServerPicker.tsx
+++ b/ui/components/ServerPicker.tsx
@@ -17,7 +17,7 @@ export function ServerPicker({
   }
 
   return (
-    <FormGroup label="Via server">
+    <FormGroup>
       <div className="form-row">
         <Select
           value={serverId}

--- a/ui/components/ServerPicker.tsx
+++ b/ui/components/ServerPicker.tsx
@@ -21,6 +21,7 @@ export function ServerPicker({
       <div className="form-row">
         <Select
           value={serverId}
+          label="Via server"
           onChange={(v) => onChange(v === 'null' ? null : v)}
         >
           <option value="null">No</option>

--- a/ui/components/TimeSeriesRange.tsx
+++ b/ui/components/TimeSeriesRange.tsx
@@ -121,7 +121,7 @@ export function TimeSeriesRange({
   const fieldName = 'range-type-' + uuid.v4();
 
   return (
-    <FormGroup label="Time Range">
+    <FormGroup>
       {!hideField && (
         <div className="form-row">
           <FieldPicker

--- a/ui/components/Tooltip.tsx
+++ b/ui/components/Tooltip.tsx
@@ -1,9 +1,12 @@
+import { IconHelp } from '@tabler/icons';
 import React from 'react';
 
 export function Tooltip({ children }: { children: React.ReactNode }) {
   return (
     <span className="tooltip">
-      <span className="tooltip-icon material-icons-outlined">help_outline</span>
+      <span className="tooltip-icon">
+        <IconHelp />
+      </span>
       <span className="tooltip-body">{children}</span>
     </span>
   );

--- a/ui/connectors/Auth.tsx
+++ b/ui/connectors/Auth.tsx
@@ -24,7 +24,7 @@ export function Auth(props: {
   );
 
   return (
-    <FormGroup label="Authentication">
+    <FormGroup>
       <div className="form-row">
         <Select
           label="Authentication"

--- a/ui/connectors/CassandraDetails.tsx
+++ b/ui/connectors/CassandraDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 import { Database } from './Database';
 import { Host } from './Host';
@@ -15,14 +16,16 @@ export function CassandraDetails(props: {
 
   return (
     <React.Fragment>
-      <Host connector={connector} updateConnector={updateConnector} />
-      <Database
-        label="Keyspace"
-        connector={connector}
-        updateConnector={updateConnector}
-      />
-      <Username {...props} />
-      <Password {...props} />
+      <FormGroup>
+        <Host connector={connector} updateConnector={updateConnector} />
+        <Database
+          label="Keyspace"
+          connector={connector}
+          updateConnector={updateConnector}
+        />
+        <Username {...props} />
+        <Password {...props} />
+      </FormGroup>
       <ServerPicker
         servers={servers}
         serverId={connector.serverId}

--- a/ui/connectors/ElasticsearchDetails.tsx
+++ b/ui/connectors/ElasticsearchDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 import { Auth } from './Auth';
 import { Host } from './Host';
@@ -13,7 +14,9 @@ export function ElasticsearchDetails(props: {
 
   return (
     <React.Fragment>
-      <Host {...props} />
+      <FormGroup>
+        <Host {...props} />
+      </FormGroup>
       <Auth {...props} apiKeyLabel="Base64 Encoded API Key" />
       <ServerPicker
         servers={servers}

--- a/ui/connectors/FluxDetails.tsx
+++ b/ui/connectors/FluxDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 import { ApiKey } from './ApiKey';
 import { Database } from './Database';
@@ -14,9 +15,11 @@ export function FluxDetails(props: {
 
   return (
     <React.Fragment>
-      <Host {...props} />
-      <Database label="Organization" {...props} />
-      <ApiKey {...props} />
+      <FormGroup>
+        <Host {...props} />
+        <Database label="Organization" {...props} />
+        <ApiKey {...props} />
+      </FormGroup>
       <ServerPicker
         servers={servers}
         serverId={connector.serverId}

--- a/ui/connectors/GenericDetails.tsx
+++ b/ui/connectors/GenericDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 import { Database } from './Database';
 import { Host } from './Host';
@@ -18,12 +19,14 @@ export function GenericDetails(props: GenericDetailsProps) {
 
   return (
     <React.Fragment>
-      <Host connector={connector} updateConnector={updateConnector} />
-      {skipDatabase ? null : (
-        <Database connector={connector} updateConnector={updateConnector} />
-      )}
-      <Username connector={connector} updateConnector={updateConnector} />
-      <Password connector={connector} updateConnector={updateConnector} />
+      <FormGroup>
+        <Host connector={connector} updateConnector={updateConnector} />
+        {skipDatabase ? null : (
+          <Database connector={connector} updateConnector={updateConnector} />
+        )}
+        <Username connector={connector} updateConnector={updateConnector} />
+        <Password connector={connector} updateConnector={updateConnector} />
+      </FormGroup>
       <ServerPicker
         servers={servers}
         serverId={connector.serverId}

--- a/ui/connectors/InfluxDetails.tsx
+++ b/ui/connectors/InfluxDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 import { Host } from './Host';
 import { Password } from './Password';
@@ -14,9 +15,11 @@ export function InfluxDetails(props: {
 
   return (
     <React.Fragment>
-      <Host {...props} />
-      <Username {...props} />
-      <Password {...props} />
+      <FormGroup>
+        <Host {...props} />
+        <Username {...props} />
+        <Password {...props} />
+      </FormGroup>
       <ServerPicker
         servers={servers}
         serverId={connector.serverId}

--- a/ui/connectors/SQLiteDetails.tsx
+++ b/ui/connectors/SQLiteDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DatabaseConnectorInfo, ServerInfo } from '../../shared/state';
 import { FileInput } from '../components/FileInput';
+import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
 
 export function SQLiteDetails({
@@ -14,16 +15,18 @@ export function SQLiteDetails({
 }) {
   return (
     <React.Fragment>
-      <FileInput
-        label="File"
-        value={connector.database.database}
-        allowManualEntry
-        allowFilePicker={!connector.serverId ? true : false}
-        onChange={(fileName: string) => {
-          connector.database.database = fileName;
-          updateConnector(connector);
-        }}
-      />
+      <FormGroup>
+        <FileInput
+          label="File"
+          value={connector.database.database}
+          allowManualEntry
+          allowFilePicker={!connector.serverId ? true : false}
+          onChange={(fileName: string) => {
+            connector.database.database = fileName;
+            updateConnector(connector);
+          }}
+        />
+      </FormGroup>
       <ServerPicker
         servers={servers}
         serverId={connector.serverId}

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,11 +2,6 @@
 
 <link rel="stylesheet" type="text/css" href="style.css" />
 
-<link
-  href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
-  rel="stylesheet"
-/>
-
 <div id="root">
   <div class="loading">Loading...</div>
 </div>

--- a/ui/panels/FilePanel.tsx
+++ b/ui/panels/FilePanel.tsx
@@ -43,7 +43,7 @@ export function FilePanelDetails({
   const { servers } = React.useContext(ProjectContext).state;
   return (
     <div className="FilePanel">
-      <FormGroup label="General">
+      <FormGroup>
         <div className="form-row">
           <FileInput
             label="File"

--- a/ui/panels/FilterAggregatePanel.test.jsx
+++ b/ui/panels/FilterAggregatePanel.test.jsx
@@ -26,25 +26,25 @@ test('shows filagg panel details', async () => {
     <FilterAggregatePanelDetails
       panel={project.pages[0].panels[1]}
       panels={project.pages[0].panels}
-	updatePanel={(p) => {
-	    project.pages[0].panels[1] = p;
-	}}
+      updatePanel={(p) => {
+        project.pages[0].panels[1] = p;
+      }}
     />
   );
 
-    await componentLoad(component);
+  await componentLoad(component);
 
-    expect(fp.filagg.sortAsc).toBe(false);
-    const sortDirection = () => component.find('[data-test-id="sort-direction"] select');
-    await sortDirection()
-	.simulate('change', { target: { value: 'asc' } });
-    expect(fp.filagg.sortAsc).toBe(true);
-    component.setProps();
-    expect(sortDirection().props().value).toBe('asc');
+  expect(fp.filagg.sortAsc).toBe(false);
+  const sortDirection = () =>
+    component.find('[data-test-id="sort-direction"] select');
+  await sortDirection().simulate('change', { target: { value: 'asc' } });
+  expect(fp.filagg.sortAsc).toBe(true);
+  component.setProps();
+  expect(sortDirection().props().value).toBe('asc');
 
-    const sortField = () => component.find('[data-test-id="sort-field"] input');
-    await sortField().simulate('change', { target: { value: 'flubberty' } });
-    await wait();
-    expect(fp.filagg.sortOn).toBe('flubberty');
-    expect(sortField().props().value).toBe('flubberty');
+  const sortField = () => component.find('[data-test-id="sort-field"] input');
+  await sortField().simulate('change', { target: { value: 'flubberty' } });
+  await wait();
+  expect(fp.filagg.sortOn).toBe('flubberty');
+  expect(sortField().props().value).toBe('flubberty');
 });

--- a/ui/panels/FilterAggregatePanel.test.jsx
+++ b/ui/panels/FilterAggregatePanel.test.jsx
@@ -1,5 +1,7 @@
 const React = require('react');
 const { act } = require('react-dom/test-utils');
+const { wait } = require('../../shared/promise');
+const { INPUT_SYNC_PERIOD } = require('../components/Input');
 const enzyme = require('enzyme');
 const {
   ProjectState,
@@ -22,10 +24,27 @@ project.pages[0].panels = [lp, fp];
 test('shows filagg panel details', async () => {
   const component = enzyme.mount(
     <FilterAggregatePanelDetails
-      panel={fp}
+      panel={project.pages[0].panels[1]}
       panels={project.pages[0].panels}
-      updatePanel={() => {}}
+	updatePanel={(p) => {
+	    project.pages[0].panels[1] = p;
+	}}
     />
   );
-  await componentLoad(component);
+
+    await componentLoad(component);
+
+    expect(fp.filagg.sortAsc).toBe(false);
+    const sortDirection = () => component.find('[data-test-id="sort-direction"] select');
+    await sortDirection()
+	.simulate('change', { target: { value: 'asc' } });
+    expect(fp.filagg.sortAsc).toBe(true);
+    component.setProps();
+    expect(sortDirection().props().value).toBe('asc');
+
+    const sortField = () => component.find('[data-test-id="sort-field"] input');
+    await sortField().simulate('change', { target: { value: 'flubberty' } });
+    await wait();
+    expect(fp.filagg.sortOn).toBe('flubberty');
+    expect(sortField().props().value).toBe('flubberty');
 });

--- a/ui/panels/FilterAggregatePanel.tsx
+++ b/ui/panels/FilterAggregatePanel.tsx
@@ -109,13 +109,17 @@ export function FilterAggregatePanelDetails({
       .resultMeta || new PanelResult();
 
   if (panels.length <= 1) {
-    return 'This panel can only build on other panels. Create another panel first.';
+    return (
+      <p>
+        This panel can only build on other panels. Create another panel first.
+      </p>
+    );
   }
 
   return (
     <React.Fragment>
-        <FormGroup>
-          <div className="form-row">
+      <FormGroup>
+        <div className="form-row">
           <PanelSourcePicker
             currentPanel={panel.id}
             panels={panels}
@@ -125,168 +129,168 @@ export function FilterAggregatePanelDetails({
               updatePanel(panel);
             }}
           />
-          </div>
-          <div className="form-row">
-            <CodeEditor
-              singleLine
-              id={panel.id + 'filter'}
-              label="Filter"
-              placeholder="x LIKE '%town%' AND y IN (1, 2)"
-              value={panel.filagg.filter}
-              onChange={(value: string) => {
-                panel.filagg.filter = value;
-                updatePanel(panel);
-              }}
-              language="sql"
-              className="editor"
-              tooltip="Use any valid SQLite WHERE expression."
-            />
-          </div>
-          {MODE !== 'browser' && (
-            <TimeSeriesRange
-              shape={data.shape}
-              range={panel.filagg.range}
-              updateRange={(r: TimeSeriesRangeT) => {
-                panel.filagg.range = r;
-                updatePanel(panel);
-              }}
-              timeFieldTooltip={
-                'Column must be a date field in ISO8601/RFC3339 format.'
-              }
-            />
-          )}
-          </FormGroup>
-          <FormGroup>
+        </div>
+        <div className="form-row">
+          <CodeEditor
+            singleLine
+            id={panel.id + 'filter'}
+            label="Filter"
+            placeholder="x LIKE '%town%' AND y IN (1, 2)"
+            value={panel.filagg.filter}
+            onChange={(value: string) => {
+              panel.filagg.filter = value;
+              updatePanel(panel);
+            }}
+            language="sql"
+            className="editor"
+            tooltip="Use any valid SQLite WHERE expression."
+          />
+        </div>
+        {MODE !== 'browser' && (
+          <TimeSeriesRange
+            shape={data.shape}
+            range={panel.filagg.range}
+            updateRange={(r: TimeSeriesRangeT) => {
+              panel.filagg.range = r;
+              updatePanel(panel);
+            }}
+            timeFieldTooltip={
+              'Column must be a date field in ISO8601/RFC3339 format.'
+            }
+          />
+        )}
+      </FormGroup>
+      <FormGroup>
+        <div className="form-row">
+          <Select
+            label="Aggregate"
+            value={panel.filagg.aggregateType}
+            onChange={(value: string) => {
+              panel.filagg.aggregateType = value as AggregateType;
+              updatePanel(panel);
+            }}
+          >
+            <optgroup label="Disabled">
+              <option value="none">None</option>
+            </optgroup>
+            <optgroup label="Enabled">
+              <option value="count">Count</option>
+              <option value="sum">Sum</option>
+              <option value="average">Average</option>
+              <option value="min">Min</option>
+              <option value="max">Max</option>
+            </optgroup>
+          </Select>
+        </div>
+        {panel.filagg.aggregateType !== 'none' && (
+          <React.Fragment>
             <div className="form-row">
-              <Select
-                label="Aggregate"
-                value={panel.filagg.aggregateType}
-                onChange={(value: string) => {
-                  panel.filagg.aggregateType = value as AggregateType;
-                  updatePanel(panel);
-                }}
-              >
-                <optgroup label="Disabled">
-                  <option value="none">None</option>
-                </optgroup>
-                <optgroup label="Enabled">
-                  <option value="count">Count</option>
-                  <option value="sum">Sum</option>
-                  <option value="average">Average</option>
-                  <option value="min">Min</option>
-                  <option value="max">Max</option>
-                </optgroup>
-              </Select>
-            </div>
-            {panel.filagg.aggregateType !== 'none' && (
-              <React.Fragment>
-                <div className="form-row">
-                  <FieldPicker
-                    preferredDefaultType="string"
-                    label="Group by"
-                    shape={data?.shape}
-                    value={panel.filagg.groupBy}
-                    onChange={(value: string) => {
-                      panel.filagg.groupBy = value;
-                      updatePanel(panel);
-                    }}
-                  />
-                </div>
-                {panel.filagg.aggregateType !== 'count' && (
-                  <div className="form-row">
-                    <FieldPicker
-                      preferredDefaultType="number"
-                      label={title(panel.filagg.aggregateType) + ' on'}
-                      shape={data?.shape}
-                      value={panel.filagg.aggregateOn}
-                      onChange={(value: string) => {
-                        panel.filagg.aggregateOn = value;
-                        updatePanel(panel);
-                      }}
-                    />
-                  </div>
-                )}
-                {MODE !== 'browser' && (
-                  <div className="form-row">
-                    <Select
-                      label="With Time Interval"
-                      value={panel.filagg.windowInterval}
-                      onChange={(value: string) => {
-                        panel.filagg.windowInterval = value;
-                        updatePanel(panel);
-                      }}
-                      tooltip={`If used, the above "Group by" column must be a date field in ISO8601/RFC3339 format.`}
-                    >
-                      <optgroup label="None">
-                        <option value="0">None</option>
-                      </optgroup>
-                      <optgroup label="Up to a day">
-                        <option value="1">1 Minute</option>
-                        <option value="5">5 Minutes</option>
-                        <option value="15">15 Minutes</option>
-                        <option value="30">30 Minutes</option>
-                        <option value="60">1 Hour</option>
-                        <option value="180">3 Hours</option>
-                        <option value={String(60 * 6)}>6 Hours</option>
-                        <option value={String(60 * 12)}>12 Hours</option>
-                        <option value={String(60 * 24)}>1 Day</option>
-                      </optgroup>
-                      <optgroup label="Up to a month">
-                        <option value={String(60 * 24 * 3)}>3 Days</option>
-                        <option value={String(60 * 24 * 7)}>7 days</option>
-                        <option value={String(60 * 24 * 7 * 2)}>14 days</option>
-                        <option value={String(60 * 24 * 30)}>30 days</option>
-                      </optgroup>
-                      <optgroup label="Up to a year">
-                        <option value={String(60 * 24 * 90)}>90 Days</option>
-                        <option value={String(60 * 24 * 180)}>180 Days</option>
-                        <option value={String(60 * 24 * 365)}>1 Year</option>
-                      </optgroup>
-                    </Select>
-                  </div>
-                )}
-              </React.Fragment>
-            )}
-            </FormGroup>
-            <FormGroup>
-            <div className="form-row form-row--multi">
               <FieldPicker
-                preferredDefaultType="number"
-                label="Sort"
-              data-test-id="sort-field"
-                shape={withAggregateShape(data, panel)}
-                value={panel.filagg.sortOn}
+                preferredDefaultType="string"
+                label="Group by"
+                shape={data?.shape}
+                value={panel.filagg.groupBy}
                 onChange={(value: string) => {
-                  panel.filagg.sortOn = value;
+                  panel.filagg.groupBy = value;
                   updatePanel(panel);
                 }}
               />
-              <Select
-                data-test-id="sort-direction"
-                label="Direction"
-                value={panel.filagg.sortAsc ? 'asc' : 'desc'}
-                onChange={(value: string) => {
-                  panel.filagg.sortAsc = value === 'asc';
-                  updatePanel(panel);
-                }}
-              >
-                <option value="desc">Descending</option>
-                <option value="asc">Ascending</option>
-              </Select>
             </div>
-            <div className="form-row">
-              <Input
-                label="Limit"
-                onChange={(value: string) => {
-                  panel.filagg.limit = +value;
-                  updatePanel(panel);
-                }}
-                value={String(panel.filagg.limit)}
-                min={1}
-                type="number"
-              />
-            </div>
-            </FormGroup>
+            {panel.filagg.aggregateType !== 'count' && (
+              <div className="form-row">
+                <FieldPicker
+                  preferredDefaultType="number"
+                  label={title(panel.filagg.aggregateType) + ' on'}
+                  shape={data?.shape}
+                  value={panel.filagg.aggregateOn}
+                  onChange={(value: string) => {
+                    panel.filagg.aggregateOn = value;
+                    updatePanel(panel);
+                  }}
+                />
+              </div>
+            )}
+            {MODE !== 'browser' && (
+              <div className="form-row">
+                <Select
+                  label="With Time Interval"
+                  value={panel.filagg.windowInterval}
+                  onChange={(value: string) => {
+                    panel.filagg.windowInterval = value;
+                    updatePanel(panel);
+                  }}
+                  tooltip={`If used, the above "Group by" column must be a date field in ISO8601/RFC3339 format.`}
+                >
+                  <optgroup label="None">
+                    <option value="0">None</option>
+                  </optgroup>
+                  <optgroup label="Up to a day">
+                    <option value="1">1 Minute</option>
+                    <option value="5">5 Minutes</option>
+                    <option value="15">15 Minutes</option>
+                    <option value="30">30 Minutes</option>
+                    <option value="60">1 Hour</option>
+                    <option value="180">3 Hours</option>
+                    <option value={String(60 * 6)}>6 Hours</option>
+                    <option value={String(60 * 12)}>12 Hours</option>
+                    <option value={String(60 * 24)}>1 Day</option>
+                  </optgroup>
+                  <optgroup label="Up to a month">
+                    <option value={String(60 * 24 * 3)}>3 Days</option>
+                    <option value={String(60 * 24 * 7)}>7 days</option>
+                    <option value={String(60 * 24 * 7 * 2)}>14 days</option>
+                    <option value={String(60 * 24 * 30)}>30 days</option>
+                  </optgroup>
+                  <optgroup label="Up to a year">
+                    <option value={String(60 * 24 * 90)}>90 Days</option>
+                    <option value={String(60 * 24 * 180)}>180 Days</option>
+                    <option value={String(60 * 24 * 365)}>1 Year</option>
+                  </optgroup>
+                </Select>
+              </div>
+            )}
+          </React.Fragment>
+        )}
+      </FormGroup>
+      <FormGroup>
+        <div className="form-row form-row--multi">
+          <FieldPicker
+            preferredDefaultType="number"
+            label="Sort"
+            data-test-id="sort-field"
+            shape={withAggregateShape(data, panel)}
+            value={panel.filagg.sortOn}
+            onChange={(value: string) => {
+              panel.filagg.sortOn = value;
+              updatePanel(panel);
+            }}
+          />
+          <Select
+            data-test-id="sort-direction"
+            label="Direction"
+            value={panel.filagg.sortAsc ? 'asc' : 'desc'}
+            onChange={(value: string) => {
+              panel.filagg.sortAsc = value === 'asc';
+              updatePanel(panel);
+            }}
+          >
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+          </Select>
+        </div>
+        <div className="form-row">
+          <Input
+            label="Limit"
+            onChange={(value: string) => {
+              panel.filagg.limit = +value;
+              updatePanel(panel);
+            }}
+            value={String(panel.filagg.limit)}
+            min={1}
+            type="number"
+          />
+        </div>
+      </FormGroup>
     </React.Fragment>
   );
 }

--- a/ui/panels/FilterAggregatePanel.tsx
+++ b/ui/panels/FilterAggregatePanel.tsx
@@ -108,10 +108,14 @@ export function FilterAggregatePanelDetails({
     ((panels || []).find((p) => p.id === panel.filagg.panelSource) || {})
       .resultMeta || new PanelResult();
 
+  if (panels.length <= 1) {
+    return 'This panel can only build on other panels. Create another panel first.';
+  }
+
   return (
     <React.Fragment>
-      <FormGroup label="General">
-        <div className="form-row">
+        <FormGroup>
+          <div className="form-row">
           <PanelSourcePicker
             currentPanel={panel.id}
             panels={panels}
@@ -121,47 +125,41 @@ export function FilterAggregatePanelDetails({
               updatePanel(panel);
             }}
           />
-        </div>
-      </FormGroup>
-      <div className="flex">
-        <div>
-          <FormGroup label="Filter">
-            <div className="form-row">
-              <CodeEditor
-                singleLine
-                id={panel.id + 'filter'}
-                label="Expression"
-                placeholder="x LIKE '%town%' AND y IN (1, 2)"
-                value={panel.filagg.filter}
-                onChange={(value: string) => {
-                  panel.filagg.filter = value;
-                  updatePanel(panel);
-                }}
-                language="sql"
-                className="editor"
-                tooltip="Use any valid SQLite WHERE expression."
-              />
-            </div>
-            {MODE !== 'browser' && (
-              <TimeSeriesRange
-                shape={data.shape}
-                range={panel.filagg.range}
-                updateRange={(r: TimeSeriesRangeT) => {
-                  panel.filagg.range = r;
-                  updatePanel(panel);
-                }}
-                timeFieldTooltip={
-                  'Column must be a date field in ISO8601/RFC3339 format.'
-                }
-              />
-            )}
+          </div>
+          <div className="form-row">
+            <CodeEditor
+              singleLine
+              id={panel.id + 'filter'}
+              label="Filter"
+              placeholder="x LIKE '%town%' AND y IN (1, 2)"
+              value={panel.filagg.filter}
+              onChange={(value: string) => {
+                panel.filagg.filter = value;
+                updatePanel(panel);
+              }}
+              language="sql"
+              className="editor"
+              tooltip="Use any valid SQLite WHERE expression."
+            />
+          </div>
+          {MODE !== 'browser' && (
+            <TimeSeriesRange
+              shape={data.shape}
+              range={panel.filagg.range}
+              updateRange={(r: TimeSeriesRangeT) => {
+                panel.filagg.range = r;
+                updatePanel(panel);
+              }}
+              timeFieldTooltip={
+                'Column must be a date field in ISO8601/RFC3339 format.'
+              }
+            />
+          )}
           </FormGroup>
-        </div>
-        <div>
-          <FormGroup label="Aggregate">
+          <FormGroup>
             <div className="form-row">
               <Select
-                label="Function"
+                label="Aggregate"
                 value={panel.filagg.aggregateType}
                 onChange={(value: string) => {
                   panel.filagg.aggregateType = value as AggregateType;
@@ -249,12 +247,12 @@ export function FilterAggregatePanelDetails({
                 )}
               </React.Fragment>
             )}
-          </FormGroup>
-          <FormGroup label="Sort">
+            </FormGroup>
+            <FormGroup>
             <div className="form-row form-row--multi">
               <FieldPicker
                 preferredDefaultType="number"
-                label="Field"
+                label="Sort"
               data-test-id="sort-field"
                 shape={withAggregateShape(data, panel)}
                 value={panel.filagg.sortOn}
@@ -276,8 +274,6 @@ export function FilterAggregatePanelDetails({
                 <option value="asc">Ascending</option>
               </Select>
             </div>
-          </FormGroup>
-          <FormGroup label="Limit">
             <div className="form-row">
               <Input
                 label="Limit"
@@ -290,9 +286,7 @@ export function FilterAggregatePanelDetails({
                 type="number"
               />
             </div>
-          </FormGroup>
-        </div>
-      </div>
+            </FormGroup>
     </React.Fragment>
   );
 }

--- a/ui/panels/FilterAggregatePanel.tsx
+++ b/ui/panels/FilterAggregatePanel.tsx
@@ -255,6 +255,7 @@ export function FilterAggregatePanelDetails({
               <FieldPicker
                 preferredDefaultType="number"
                 label="Field"
+              data-test-id="sort-field"
                 shape={withAggregateShape(data, panel)}
                 value={panel.filagg.sortOn}
                 onChange={(value: string) => {
@@ -263,8 +264,9 @@ export function FilterAggregatePanelDetails({
                 }}
               />
               <Select
+                data-test-id="sort-direction"
                 label="Direction"
-                value={panel.filagg.aggregateType}
+                value={panel.filagg.sortAsc ? 'asc' : 'desc'}
                 onChange={(value: string) => {
                   panel.filagg.sortAsc = value === 'asc';
                   updatePanel(panel);

--- a/ui/panels/GraphPanel.tsx
+++ b/ui/panels/GraphPanel.tsx
@@ -6,7 +6,7 @@ import {
   GraphField,
   GraphPanelInfo,
   GraphPanelInfoType,
-  GraphPanelInfoWidth,
+  PanelInfoWidth,
   PanelInfo,
   PanelResult,
 } from '../../shared/state';
@@ -311,7 +311,7 @@ export function GraphPanelDetails({
     <React.Fragment>
       <div className="flex">
         <div>
-          <FormGroup label="General">
+          <FormGroup>
             <div className="form-row">
               <PanelSourcePicker
                 currentPanel={panel.id}
@@ -323,11 +323,26 @@ export function GraphPanelDetails({
                 }}
               />
             </div>
+            <div className="form-row">
+              <Radio
+                label="Width"
+                value={panel.graph.width}
+                onChange={(value: string) => {
+                  panel.graph.width = value as PanelInfoWidth;
+                  updatePanel(panel);
+                }}
+                options={[
+                  { label: 'Default', value: 'small' },
+                  { label: '75%', value: 'medium' },
+                  { label: '100%', value: 'large' },
+                ]}
+              />
+            </div>
           </FormGroup>
-          <FormGroup label={panel.graph.type === 'pie' ? 'Slice' : 'X-Axis'}>
+          <FormGroup>
             <div className="form-row">
               <FieldPicker
-                label="Field"
+                label={panel.graph.type === 'pie' ? 'Slice' : 'X-Axis'}
                 shape={data?.shape}
                 value={panel.graph.x}
                 onChange={(value: string) => {
@@ -336,12 +351,6 @@ export function GraphPanelDetails({
                 }}
               />
             </div>
-          </FormGroup>
-          <FormGroup
-            label={
-              panel.graph.type === 'pie' ? 'Slice Size Series' : 'Y-Axis Series'
-            }
-          >
             {panel.graph.ys.map((y, i) => (
               <div
                 className="form-row form-row--multi vertical-align-center"
@@ -349,12 +358,14 @@ export function GraphPanelDetails({
               >
                 <FieldPicker
                   used={[...panel.graph.ys.map((y) => y.field), panel.graph.x]}
-                  onDelete={() => {
+                  onDelete={panel.graph.ys.length > 1 ? () => {
                     panel.graph.ys.splice(i, 1);
                     updatePanel(panel);
-                  }}
+                  } : undefined}
                   preferredDefaultType="number"
-                  label="Field"
+                  label={
+              panel.graph.type === 'pie' ? 'Slice Size Series' : 'Y-Axis Series'
+            }
                   value={y.field}
                   shape={data?.shape}
                   onChange={(value: string) => {
@@ -380,7 +391,7 @@ export function GraphPanelDetails({
           </FormGroup>
         </div>
         <div>
-          <FormGroup label="Display">
+          <FormGroup>
             <div className="form-row">
               <Select
                 label="Graph Type"
@@ -397,7 +408,7 @@ export function GraphPanelDetails({
             </div>
             <div className="form-row">
               <Radio
-                label="Unique Colors"
+                label="Unique Colors within Series"
                 value={String(panel.graph.colors.unique)}
                 onChange={(value: string) => {
                   panel.graph.colors.unique = value === 'true';
@@ -406,21 +417,6 @@ export function GraphPanelDetails({
                 options={[
                   { label: 'Yes', value: 'true' },
                   { label: 'No', value: 'false' },
-                ]}
-              />
-            </div>
-            <div className="form-row">
-              <Radio
-                label="Width"
-                value={panel.graph.width}
-                onChange={(value: string) => {
-                  panel.graph.width = value as GraphPanelInfoWidth;
-                  updatePanel(panel);
-                }}
-                options={[
-                  { label: 'Small', value: 'small' },
-                  { label: 'Medium', value: 'medium' },
-                  { label: 'Large', value: 'large' },
                 ]}
               />
             </div>

--- a/ui/panels/GraphPanel.tsx
+++ b/ui/panels/GraphPanel.tsx
@@ -6,8 +6,8 @@ import {
   GraphField,
   GraphPanelInfo,
   GraphPanelInfoType,
-  PanelInfoWidth,
   PanelInfo,
+  PanelInfoWidth,
   PanelResult,
 } from '../../shared/state';
 import { Button } from '../components/Button';
@@ -358,14 +358,20 @@ export function GraphPanelDetails({
               >
                 <FieldPicker
                   used={[...panel.graph.ys.map((y) => y.field), panel.graph.x]}
-                  onDelete={panel.graph.ys.length > 1 ? () => {
-                    panel.graph.ys.splice(i, 1);
-                    updatePanel(panel);
-                  } : undefined}
+                  onDelete={
+                    panel.graph.ys.length > 1
+                      ? () => {
+                          panel.graph.ys.splice(i, 1);
+                          updatePanel(panel);
+                        }
+                      : undefined
+                  }
                   preferredDefaultType="number"
                   label={
-              panel.graph.type === 'pie' ? 'Slice Size Series' : 'Y-Axis Series'
-            }
+                    panel.graph.type === 'pie'
+                      ? 'Slice Size Series'
+                      : 'Y-Axis Series'
+                  }
                   value={y.field}
                   shape={data?.shape}
                   onChange={(value: string) => {

--- a/ui/panels/HTTPPanel.tsx
+++ b/ui/panels/HTTPPanel.tsx
@@ -50,7 +50,7 @@ export function HTTPPanelDetails({
   const { servers } = React.useContext(ProjectContext).state;
   return (
     <React.Fragment>
-      <FormGroup label="General">
+      <FormGroup>
         <div className="form-row">
           <Select
             label="Method"
@@ -89,12 +89,12 @@ export function HTTPPanelDetails({
         />
       </FormGroup>
 
-      <FormGroup label="Headers">
+      <FormGroup>
         {panel.http.http.headers.map(
           (header: { value: string; name: string }, headerIndex: number) => (
             <div className="form-row form-row--multi vertical-align-center">
               <Input
-                label="Name"
+                label="Header"
                 value={header.name}
                 onChange={(value: string) => {
                   header.name = value;

--- a/ui/panels/HTTPPanel.tsx
+++ b/ui/panels/HTTPPanel.tsx
@@ -1,3 +1,4 @@
+import { IconTrash } from '@tabler/icons';
 import { preview } from 'preview';
 import * as React from 'react';
 import { shape } from 'shape';
@@ -117,7 +118,7 @@ export function HTTPPanelDetails({
                 }}
                 type="outline"
               >
-                delete
+                <IconTrash />
               </Button>
             </div>
           )

--- a/ui/panels/TablePanel.tsx
+++ b/ui/panels/TablePanel.tsx
@@ -9,6 +9,7 @@ import {
   PanelResult,
   TableColumn,
   TablePanelInfo,
+  PanelInfoWidth,
 } from '../../shared/state';
 import { columnsFromObject } from '../../shared/table';
 import { panelRPC } from '../asyncRPC';
@@ -203,10 +204,10 @@ export function TablePanel({ panel, panels }: PanelBodyProps<TablePanelInfo>) {
         </tr>
       </thead>
       <tbody>
-        {valueAsArray.map(function mapRows(row: any) {
+        {valueAsArray.map(function mapRows(row: any, i: number) {
           return (
             /* probably a better way to do this... */ <tr
-              key={Object.values(row).join(',')}
+              key={Object.values(row).join(',')+i}
             >
               {panel.table.columns.map(function mapColumnToCell(
                 column: TableColumn,

--- a/ui/panels/TablePanel.tsx
+++ b/ui/panels/TablePanel.tsx
@@ -1,4 +1,5 @@
 import { preview } from 'preview';
+import { Radio } from '../components/Radio';
 import * as React from 'react';
 import { shape } from 'shape';
 import { MODE } from '../../shared/constants';
@@ -104,7 +105,7 @@ export function TablePanelDetails({
 
   return (
     <React.Fragment>
-      <FormGroup label="General">
+      <FormGroup>
         <div className="form-row">
           <PanelSourcePicker
             currentPanel={panel.id}
@@ -116,18 +117,33 @@ export function TablePanelDetails({
             }}
           />
         </div>
-      </FormGroup>
-      <FormGroup label="Columns">
-        {panel.table.columns.map(function mapColumnRender(c, i) {
-          return (
-            <div className="form-row vertical-align-center" key={c.field + i}>
-              <FieldPicker
-                used={panel.table.columns.map(mapColumnToField)}
-                onDelete={function handleColumnDelete() {
-                  panel.table.columns.splice(i, 1);
+        <div className="form-row">
+              <Radio
+                label="Width"
+                value={panel.table.width}
+                onChange={(value: string) => {
+                  panel.table.width = value as PanelInfoWidth;
                   updatePanel(panel);
                 }}
-                label="Field"
+                options={[
+                  { label: 'Default', value: 'small' },
+                  { label: '75%', value: 'medium' },
+                  { label: '100%', value: 'large' },
+                ]}
+              />
+            </div>
+      </FormGroup>
+      <FormGroup>
+        {panel.table.columns.map(function mapColumnRender(c, i) {
+          return (
+            <div className="form-row form-row--multi vertical-align-center" key={c.field + i}>
+              <FieldPicker
+                used={panel.table.columns.map(mapColumnToField)}
+                onDelete={panel.table.columns.length > 1 ? function handleColumnDelete() {
+                  panel.table.columns.splice(i, 1);
+                  updatePanel(panel);
+                }: undefined}
+                label="Column"
                 value={c.field}
                 shape={data?.shape}
                 onChange={function handleFieldChange(value: string) {
@@ -175,7 +191,7 @@ export function TablePanel({ panel, panels }: PanelBodyProps<TablePanelInfo>) {
   // column key is (field + i) everywhere because columns can be
   // duplicated. Maybe should assign a uuid to them instead
   return (
-    <table>
+    <table className={`table table--${panel.table.width}`}>
       <thead>
         <tr>
           {panel.table.columns.map(function mapColumnToHeader(

--- a/ui/panels/TablePanel.tsx
+++ b/ui/panels/TablePanel.tsx
@@ -120,6 +120,20 @@ export function TablePanelDetails({
         </div>
         <div className="form-row">
           <Radio
+            label="Row Numbers"
+            value={String(panel.table.rowNumbers)}
+            onChange={(value: string) => {
+              panel.table.rowNumbers = value === 'true';
+              updatePanel(panel);
+            }}
+            options={[
+              { label: 'Visible', value: 'true' },
+              { label: 'Hidden', value: 'false' },
+            ]}
+          />
+        </div>
+        <div className="form-row">
+          <Radio
             label="Width"
             value={panel.table.width}
             onChange={(value: string) => {
@@ -202,6 +216,7 @@ export function TablePanel({ panel, panels }: PanelBodyProps<TablePanelInfo>) {
     <table className={`table table--${panel.table.width}`}>
       <thead>
         <tr>
+          {panel.table.rowNumbers ? <th></th> : null}
           {panel.table.columns.map(function mapColumnToHeader(
             column: TableColumn,
             i: number
@@ -216,6 +231,16 @@ export function TablePanel({ panel, panels }: PanelBodyProps<TablePanelInfo>) {
             /* probably a better way to do this... */ <tr
               key={Object.values(row).join(',') + i}
             >
+              {panel.table.rowNumbers ? (
+                <td
+                  className="text-muted"
+                  style={{
+                    width: 0 /* magically uses up least amount of space needed */,
+                  }}
+                >
+                  <small>#{i + 1}</small>
+                </td>
+              ) : null}
               {panel.table.columns.map(function mapColumnToCell(
                 column: TableColumn,
                 i: number

--- a/ui/panels/TablePanel.tsx
+++ b/ui/panels/TablePanel.tsx
@@ -1,15 +1,14 @@
 import { preview } from 'preview';
-import { Radio } from '../components/Radio';
 import * as React from 'react';
 import { shape } from 'shape';
 import { MODE } from '../../shared/constants';
 import { InvalidDependentPanelError } from '../../shared/errors';
 import {
   PanelInfo,
+  PanelInfoWidth,
   PanelResult,
   TableColumn,
   TablePanelInfo,
-  PanelInfoWidth,
 } from '../../shared/state';
 import { columnsFromObject } from '../../shared/table';
 import { panelRPC } from '../asyncRPC';
@@ -18,6 +17,7 @@ import { Button } from '../components/Button';
 import { FieldPicker, unusedFields } from '../components/FieldPicker';
 import { FormGroup } from '../components/FormGroup';
 import { PanelSourcePicker } from '../components/PanelSourcePicker';
+import { Radio } from '../components/Radio';
 import { PanelBodyProps, PanelDetailsProps, PanelUIDetails } from './types';
 
 export async function evalColumnPanel(
@@ -119,31 +119,38 @@ export function TablePanelDetails({
           />
         </div>
         <div className="form-row">
-              <Radio
-                label="Width"
-                value={panel.table.width}
-                onChange={(value: string) => {
-                  panel.table.width = value as PanelInfoWidth;
-                  updatePanel(panel);
-                }}
-                options={[
-                  { label: 'Default', value: 'small' },
-                  { label: '75%', value: 'medium' },
-                  { label: '100%', value: 'large' },
-                ]}
-              />
-            </div>
+          <Radio
+            label="Width"
+            value={panel.table.width}
+            onChange={(value: string) => {
+              panel.table.width = value as PanelInfoWidth;
+              updatePanel(panel);
+            }}
+            options={[
+              { label: 'Default', value: 'small' },
+              { label: '75%', value: 'medium' },
+              { label: '100%', value: 'large' },
+            ]}
+          />
+        </div>
       </FormGroup>
       <FormGroup>
         {panel.table.columns.map(function mapColumnRender(c, i) {
           return (
-            <div className="form-row form-row--multi vertical-align-center" key={c.field + i}>
+            <div
+              className="form-row form-row--multi vertical-align-center"
+              key={c.field + i}
+            >
               <FieldPicker
                 used={panel.table.columns.map(mapColumnToField)}
-                onDelete={panel.table.columns.length > 1 ? function handleColumnDelete() {
-                  panel.table.columns.splice(i, 1);
-                  updatePanel(panel);
-                }: undefined}
+                onDelete={
+                  panel.table.columns.length > 1
+                    ? function handleColumnDelete() {
+                        panel.table.columns.splice(i, 1);
+                        updatePanel(panel);
+                      }
+                    : undefined
+                }
                 label="Column"
                 value={c.field}
                 shape={data?.shape}
@@ -207,7 +214,7 @@ export function TablePanel({ panel, panels }: PanelBodyProps<TablePanelInfo>) {
         {valueAsArray.map(function mapRows(row: any, i: number) {
           return (
             /* probably a better way to do this... */ <tr
-              key={Object.values(row).join(',')+i}
+              key={Object.values(row).join(',') + i}
             >
               {panel.table.columns.map(function mapColumnToCell(
                 column: TableColumn,

--- a/ui/style.css
+++ b/ui/style.css
@@ -284,6 +284,11 @@ input + input[type='file'] {
   font-size: 0.75rem;
 }
 
+.horizontal-align-center {
+  display: flex;
+  justifyin-content: center;
+}
+
 .vertical-align-center {
   display: flex;
   align-items: center;
@@ -318,12 +323,6 @@ input + input[type='file'] {
   box-shadow: 0px 0px 3px var(--border-light);
 }
 
-.material-icons,
-.material-icons-outlined {
-  width: 24px;
-  height: 24px;
-}
-
 .button:hover {
   background: #f0f0f0;
 }
@@ -338,32 +337,34 @@ input + input[type='file'] {
   background: #56008c;
 }
 
-.button.material-icons,
-.button.material-icons-outlined {
+.button--icon {
   box-shadow: initial;
   border: 0;
   background: transparent;
   color: #777;
   padding: 0;
+
+  svg {
+    height: 18px;
+    width: 18px;
+  }
 }
 
-.button:not(.material-icons):not(.material-icons-outlined):disabled,
-.button:not(.material-icons):not(.material-icons-outlined):disabled:hover {
+.button:not(.button--icon):disabled,
+.button:not(.button--icon):disabled:hover {
   background: #ccc;
   color: #999;
   cursor: not-allowed;
   pointer-events: all !important;
 }
 
-.button.button--primary.material-icons,
-.button.button--primary.material-icons-outlined {
+.button.button--primary.button--icon {
+  background: transparent;
   color: #9f04ff;
 }
 
-.button.material-icons:disabled,
-.button.material-icons-outlined:disabled,
-.button.material-icons:disabled:hover,
-.button.material-icons-outlined:disabled:hover {
+.button.button--icon:disabled,
+.button.button--icon:disabled:hover {
   cursor: not-allowed;
   pointer-events: all !important;
   color: #ccc;
@@ -724,7 +725,13 @@ input + input[type='file'] {
 }
 
 .new-panel {
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .button {
+    margin: 0 5px;
+  }
 }
 
 .new-panel:not(:last-child) {
@@ -792,7 +799,7 @@ input + input[type='file'] {
   }
 }
 
-.alert > .material-icons {
+.alert > .button--icon {
   margin-right: 15px;
   color: #555;
 }
@@ -1137,8 +1144,7 @@ body.dark {
     box-shadow: 0px 0px 3px var(--border-dark);
   }
 
-  .button.material-icons,
-  .button.material-icons-outlined {
+  .button.button--icon {
     border: 0;
     box-shadow: initial;
     background: transparent;
@@ -1146,8 +1152,7 @@ body.dark {
     padding: 0;
   }
 
-  .button.material-icons.button--primary,
-  .button.material-icons-outlined.button--primary {
+  .button.button--icon.button--primary {
     color: #4fffa6;
   }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,22 +1,26 @@
 :root {
-    /* Light theme settings */
-    --background-light: #fdfdff;
-    --border-light: #d3d3e5;
-    --darker-light: #f3f3f7;
-    --button-light: #fdfdff;
+  /* Light theme settings */
+  --background-light: #fdfdff;
+  --border-light: #d3d3e5;
+  --darker-light: #f3f3f7;
+  --button-light: #fdfdff;
 
-    /* Dark theme settings */
-    --background-dark: #29293c;
+  /* Dark theme settings */
+  --background-dark: #29293c;
+  --border-dark: black;
+  --color-dark: #dfdfdf;
+  --panel-background-dark: #2a2a40;
+  --panel-background-contrast-dark: #26263a;
 
-    --sans-serif: "San Francisco", "Gadugi", sans-serif;
+  --sans-serif: 'San Francisco', 'Gadugi', sans-serif;
 }
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {
-    font-family: var(--sans-serif);
+  font-family: var(--sans-serif);
   padding: 0;
   margin: 0;
   background: var(--background-light);
@@ -30,8 +34,8 @@ a:hover {
 }
 
 .button {
-    border: 1px solid var(--border-light);
-    border-radius: 3px;
+  border: 1px solid var(--border-light);
+  border-radius: 3px;
   background: var(--button-light);
 }
 
@@ -106,7 +110,7 @@ header iframe {
 }
 
 .ace_gutter-layer {
-    background: var(--darker-light);
+  background: var(--darker-light);
 }
 
 .editor-container:not(.editor-container--singleLine) {
@@ -127,7 +131,7 @@ header iframe {
   padding: 5px;
   background: transparent;
   border: 1px solid #aaa;
-  border-radius :5px;
+  border-radius: 5px;
   min-height: 100px;
   width: 800px;
   max-width: 100%;
@@ -142,10 +146,9 @@ label,
   font-size: 0.75rem;
 }
 
-
 .panel-details :not(.form-row--multi) > .button {
-    /* Line up with everything with a label */
-    margin-left: 100px;
+  /* Line up with everything with a label */
+  margin-left: 100px;
 }
 
 .panel-details {
@@ -262,7 +265,8 @@ label.input input:not([type='radio']):not([type='file']),
 select.select,
 label.select select {
   padding: 5px;
-  border: 1px solid var(--border-light);
+  border: 0;
+  box-shadow: 0px 0px 3px var(--border-light);
   border-radius: 3px;
   background: var(--background-light);
   /* Since many inputs are within label, keep the label font size small and the input font size normal */
@@ -311,6 +315,7 @@ input + input[type='file'] {
   cursor: pointer;
   cursor: hand;
   border-radius: 3px;
+  box-shadow: 0px 0px 3px var(--border-light);
 }
 
 .material-icons,
@@ -335,16 +340,17 @@ input + input[type='file'] {
 
 .button.material-icons,
 .button.material-icons-outlined {
+  box-shadow: initial;
   border: 0;
   background: transparent;
-  color: #555;
+  color: #777;
   padding: 0;
 }
 
 .button:not(.material-icons):not(.material-icons-outlined):disabled,
 .button:not(.material-icons):not(.material-icons-outlined):disabled:hover {
   background: #ccc;
-  color: #777;
+  color: #999;
   cursor: not-allowed;
   pointer-events: all !important;
 }
@@ -414,6 +420,7 @@ input + input[type='file'] {
   padding: 8px 15px;
   background: transparent;
   border: 0;
+  box-shadow: initial;
   color: black;
   font-size: 1.2rem;
   font-weight: bold;
@@ -507,6 +514,7 @@ input + input[type='file'] {
   .button.page-name {
     border-radius: 0;
     border: 0;
+    box-shadow: initial;
     border-right: 1px solid #f9f9fd;
     padding: 15px;
     background: transparent;
@@ -546,38 +554,38 @@ input + input[type='file'] {
 }
 
 .panel {
-    transition: all .5s;
+  transition: all 0.5s;
 }
 
 .panel--fullscreen {
-    position: absolute;
-    left: 0;
-    top: 0;
-    z-index: 999;
-    height: 100%;
-    width: 100%;
-    margin: 0;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 999;
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  border: 0;
+  display: flex;
+  flex-direction: column;
+
+  .panel-header {
     border: 0;
-    display: flex;
-    flex-direction: column;
+  }
 
-    .panel-header {
-	border: 0;
+  .panel-body-container {
+    flex: 1;
+
+    .flex {
+      height: 100%;
+      flex-direction: column;
     }
 
-    .panel-body-container {
-	flex: 1;
-
-	.flex {
-	    height: 100%;
-	    flex-direction: column;
-	}
-
-	.panel-out {
-	    width: initial;
-	    height: 400px;
-	}
+    .panel-out {
+      width: initial;
+      height: 400px;
     }
+  }
 }
 
 .panel--loading {
@@ -605,7 +613,7 @@ input + input[type='file'] {
 }
 
 .panel-head {
-    padding: 8px;
+  padding: 8px;
   background: #f9f9fd;
   border-bottom: 1px solid var(--border-light);
 }
@@ -679,6 +687,7 @@ input + input[type='file'] {
 
 .panel-out-header button.button {
   border: 0 !important;
+  box-shadow: initial !important;
   background: 0;
   padding: 5px 15px;
   border-radius: 0;
@@ -885,8 +894,8 @@ input + input[type='file'] {
 
 .table,
 canvas {
-    max-height: 100%;
-    padding: 0 15px;
+  max-height: 100%;
+  padding: 0 15px;
   margin: 30px auto;
 }
 
@@ -950,15 +959,16 @@ canvas {
 }
 
 .table {
-    border-collapse: collapse;
+  border-collapse: collapse;
 
-    th {
-	text-align: left;
-    }
+  th {
+    text-align: left;
+  }
 
-    th, td {
-	padding: 5px;
-    }
+  th,
+  td {
+    padding: 5px;
+  }
 }
 
 tbody tr:nth-child(odd) {
@@ -1054,7 +1064,7 @@ body.dark a,
 body.dark a:visited,
 body.dark a:focus,
 body.dark a:hover {
-  color: white;
+  color: var(--color-dark);
 }
 
 body.dark .alert a,
@@ -1069,9 +1079,11 @@ body.dark input.input:not([type='radio']):not([type='file']),
 body.dark label.input input:not([type='radio']):not([type='file']),
 body.dark select.select,
 body.dark label.select select {
-  background: #29293c;
-  border: 1px solid black;
-  color: white;
+  background: #38384c;
+  border: 1px solid var(--border-dark);
+  box-shadow: 0px 0px 3px var(--border-dark);
+  outline: var(--border-dark);
+  color: var(--color-dark);
 }
 
 body.dark .server:hover,
@@ -1079,7 +1091,7 @@ body.dark .connector:hover,
 body.dark .server--expanded,
 body.dark .connector--expanded {
   background: #484860;
-  border-color: black;
+  border-color: var(--border-dark);
 }
 
 body.dark .button:hover {
@@ -1087,13 +1099,13 @@ body.dark .button:hover {
 }
 
 body.dark tbody tr:nth-child(odd) {
-  background: #31314e;
+  background: var(--panel-background-contrast-dark);
 }
 /* End cssplus break */
 
 body.dark {
   background: var(--background-dark);
-  color: white;
+  color: var(--color-dark);
 
   .app--desktop,
   .app--server {
@@ -1111,22 +1123,24 @@ body.dark {
 
   header {
     background: #29293c;
-    border-bottom-color: black;
+    border-bottom-color: var(--border-dark);
   }
 
   header a {
-    color: white;
+    color: var(--color-dark);
   }
 
   .button {
-    border: 1px solid black;
+    border: 1px solid var(--border-dark);
     background: #4a4a6a;
     color: #ddd;
+    box-shadow: 0px 0px 3px var(--border-dark);
   }
 
   .button.material-icons,
   .button.material-icons-outlined {
     border: 0;
+    box-shadow: initial;
     background: transparent;
     color: #999;
     padding: 0;
@@ -1138,23 +1152,22 @@ body.dark {
   }
 
   .page-name {
-    border-right-color: black;
+    border-right-color: var(--border-dark);
   }
 
   .page-name--current {
     background: #29293c;
-
-    .input {
-      background: #404066 !important;
-    }
   }
 
   .global-dropdown-item a {
     color: #61b6ff;
   }
 
-  .global-dropdown-body,
   .section-title {
+    background: var(--border-dark);
+  }
+
+  .global-dropdown-body {
     background: var(--background-dark);
   }
 
@@ -1175,29 +1188,29 @@ body.dark {
 
   .panel,
   .editor {
-    background: #484860;
+    background: var(--panel-background-dark);
   }
 
   .panel {
-    border-color: black;
+    border-color: var(--border-dark);
   }
 
   .editor {
-    color: white;
+    color: var(--color-dark);
   }
 
   .panel-head {
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid var(--border-dark);
     background: #31314e;
   }
 
   .panel-header--open {
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid var(--border-dark);
   }
 
   .pages {
     .button.page-name {
-      border-right: 1px solid var(--border-light);
+      border-right: 1px solid var(--border-dark);
     }
   }
 
@@ -1211,7 +1224,7 @@ body.dark {
 
   .panel-out-header .button.selected {
     background: #181824;
-    color: white;
+    color: var(--color-dark);
   }
 
   label,
@@ -1235,24 +1248,24 @@ body.dark {
   .sidebar,
   .project-name {
     background: #31314e;
-    border-color: black;
+    border-color: var(--border-dark);
   }
 
   .server,
   .connector {
-    border-bottom-color: black;
-    color: white;
+    border-bottom-color: var(--border-dark);
+    color: var(--color-dark);
   }
 
   .confirm-popup {
     background: #29293c;
-    color: white;
-    border-color: black;
+    color: var(--color-dark);
+    border-color: var(--border-dark);
     box-shadow: 0 1px 3px 0 #111;
   }
 
   .project-existing {
-    border-color: black;
+    border-color: var(--border-dark);
   }
 
   .input-invalid,
@@ -1261,6 +1274,6 @@ body.dark {
   }
 
   .global-dropdown p {
-    color: white;
+    color: var(--color-dark);
   }
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,12 +1,25 @@
+:root {
+    /* Light theme settings */
+    --background-light: #fdfdff;
+    --border-light: #d3d3e5;
+    --darker-light: #f3f3f7;
+    --button-light: #fdfdff;
+
+    /* Dark theme settings */
+    --background-dark: #29293c;
+
+    --sans-serif: "San Francisco", "Gadugi", sans-serif;
+}
+
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 body {
-  font-family: sans-serif;
+    font-family: var(--sans-serif);
   padding: 0;
   margin: 0;
-  background: #fbfbfb;
+  background: var(--background-light);
 }
 
 a,
@@ -17,8 +30,9 @@ a:hover {
 }
 
 .button {
-  border: 1px solid #ccc;
-  background: #fbfbfb;
+    border: 1px solid var(--border-light);
+    border-radius: 3px;
+  background: var(--button-light);
 }
 
 .loading {
@@ -28,7 +42,7 @@ a:hover {
 
 .app--desktop,
 .app--server {
-  border-top: 1px solid #ccc;
+  border-top: 1px solid var(--border-light);
   height: calc(100% - 1px);
 }
 
@@ -49,7 +63,7 @@ a:hover {
 }
 
 header {
-  background: white;
+  background: var(--background-light);
   padding: 8px 15px;
   border-bottom: 2px solid #e5e5ec;
   color: black;
@@ -81,7 +95,7 @@ header iframe {
 }
 
 .editor {
-  background: #fbfbfb;
+  background: var(--background-light);
   width: 100%;
   border: 0;
   font-family: monospace;
@@ -92,7 +106,7 @@ header iframe {
 }
 
 .ace_gutter-layer {
-  background: #d5d5d5;
+    background: var(--darker-light);
 }
 
 .editor-container:not(.editor-container--singleLine) {
@@ -113,6 +127,7 @@ header iframe {
   padding: 5px;
   background: transparent;
   border: 1px solid #aaa;
+  border-radius :5px;
   min-height: 100px;
   width: 800px;
   max-width: 100%;
@@ -127,6 +142,12 @@ label,
   font-size: 0.75rem;
 }
 
+
+.panel-details :not(.form-row--multi) > .button {
+    /* Line up with everything with a label */
+    margin-left: 100px;
+}
+
 .panel-details {
   overflow-x: auto;
 
@@ -135,8 +156,9 @@ label,
   .select-label {
     display: inline-block;
     text-align: right;
-    width: 200px; /* 200px should be more than enough for anyone */
+    width: 100px;
     padding-right: 15px;
+    overflow-wrap: break-word;
   }
 
   .form-row .form-row,
@@ -159,9 +181,10 @@ label,
   width: initial;
 }
 
+input,
 input[type='date'],
 input[type='time'] {
-  font-family: sans-serif;
+  font-family: var(--sans-serif);
 }
 
 input[type='radio'] {
@@ -211,7 +234,7 @@ input[type='radio'] {
       calc(14px * 2) + 4px
     ); /* Twice the inner circle + border width */
     height: 18px;
-    border: 2px solid #ccc;
+    border: 2px solid var(--border-light);
     border-radius: 15px;
     margin-left: 8px;
     position: relative;
@@ -239,9 +262,9 @@ label.input input:not([type='radio']):not([type='file']),
 select.select,
 label.select select {
   padding: 5px;
-  background: transparent;
-  border: 1px solid #ccc;
-  background: white;
+  border: 1px solid var(--border-light);
+  border-radius: 3px;
+  background: var(--background-light);
   /* Since many inputs are within label, keep the label font size small and the input font size normal */
   font-size: initial;
   display: inline-block;
@@ -384,7 +407,7 @@ input + input[type='file'] {
   font-size: 1.5rem;
   display: flex;
   align-items: center;
-  background: #f3f3f3;
+  background: var(--darker-light);
 }
 
 .section-title .add-page {
@@ -401,11 +424,11 @@ input + input[type='file'] {
 }
 
 .sidebar {
-  border-right: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-  background: white;
-  min-width: 350px;
-  background: #fbfbfb;
+  border-right: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-light);
+  background: var(--background-light);
+  min-width: 400px;
+  background: #f9f9fd;
   padding: 15px;
   max-height: 100%;
   overflow-y: auto;
@@ -429,7 +452,7 @@ input + input[type='file'] {
   margin-bottom: 15px;
   padding: 10px;
   border: 1px solid transparent;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-light);
 
   .connector-body,
   .server-body {
@@ -460,8 +483,8 @@ input + input[type='file'] {
 .connector:hover,
 .server--expanded,
 .connector--expanded {
-  background: white;
-  border-color: #ccc;
+  background: var(--background-light);
+  border-color: var(--border-light);
 }
 
 .server-name,
@@ -484,7 +507,7 @@ input + input[type='file'] {
   .button.page-name {
     border-radius: 0;
     border: 0;
-    border-right: 1px solid #fbfbfb;
+    border-right: 1px solid #f9f9fd;
     padding: 15px;
     background: transparent;
   }
@@ -492,7 +515,7 @@ input + input[type='file'] {
   .page-name--current {
     font-size: 1rem;
     padding: 8px 15px;
-    background: #fbfbfb;
+    background: var(--background-light);
 
     .input {
       margin: 0 8px;
@@ -517,8 +540,8 @@ input + input[type='file'] {
 
 .card,
 .panel {
-  background: white;
-  border: 1px solid #ccc;
+  background: var(--background-light);
+  border: 1px solid var(--border-light);
   margin: 15px;
 }
 
@@ -539,7 +562,7 @@ input + input[type='file'] {
 
 @keyframes pulse {
   0% {
-    background: white;
+    background: var(--background-light);
   }
 
   50% {
@@ -548,7 +571,7 @@ input + input[type='file'] {
 }
 
 .panel--hidden {
-  border-color: #ccc;
+  border-color: var(--border-light);
 }
 
 .panel-type,
@@ -558,9 +581,9 @@ input + input[type='file'] {
 }
 
 .panel-head {
-  padding: 8px;
-  background: #eaeaf1;
-  border-bottom: 1px solid #ccc;
+    padding: 8px;
+  background: #f9f9fd;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .panel--hidden .panel-head,
@@ -570,7 +593,7 @@ input + input[type='file'] {
 
 .panel-header--open {
   padding-bottom: 8px;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .panel-body-container {
@@ -622,7 +645,7 @@ input + input[type='file'] {
 }
 
 .panel-out-header {
-  background: #eaeaf1;
+  background: #f9f9fd;
 }
 
 .panel--empty .panel-out {
@@ -769,8 +792,8 @@ input + input[type='file'] {
   position: absolute;
   top: 30px;
   right: 1px;
-  background: white;
-  border: 1px solid #ccc;
+  background: var(--background-light);
+  border: 1px solid var(--border-light);
   padding: 15px;
   width: 400px;
   color: black;
@@ -836,20 +859,25 @@ input + input[type='file'] {
   padding: 30px 0;
 }
 
+.table,
 canvas {
-  max-height: 100%;
+    max-height: 100%;
+    padding: 0 15px;
   margin: 30px auto;
 }
 
+.table--small,
 .canvas--small {
   width: 1024px !important;
   max-width: 100%;
 }
 
+.table--medium,
 .canvas--medium {
   width: 75% !important;
 }
 
+.table--large,
 .canvas--large {
   width: 100% !important;
 }
@@ -865,8 +893,8 @@ canvas {
 }
 
 .modal-body {
-  background: white;
-  border: 1px solid #ccc;
+  background: var(--background-light);
+  border: 1px solid var(--border-light);
   padding: 15px;
 }
 
@@ -887,7 +915,7 @@ canvas {
 }
 
 .project-existing {
-  border-top: 1px solid #ccc;
+  border-top: 1px solid var(--border-light);
   padding-top: 15px;
   margin-top: 15px;
 
@@ -902,7 +930,7 @@ th {
 }
 
 tbody tr:nth-child(odd) {
-  background: #f2f2f7;
+  background: var(--darker-light);
 }
 
 .confirm-wrapper {
@@ -921,9 +949,9 @@ tbody tr:nth-child(odd) {
   z-index: 4;
   padding: 15px;
   min-width: 200px;
-  background: white;
+  background: var(--background-light);
   box-shadow: 0 1px 3px 0 #aaa;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-light);
   font-size: 1rem;
 }
 
@@ -962,13 +990,13 @@ tbody tr:nth-child(odd) {
   right: 0;
   top: calc(100% + 5px);
   padding: 16px;
-  background: #f3f3f3;
+  background: var(--background-light);
   width: 300px;
   box-shadow: 0 1px 3px 0 #aaa;
 }
 
 .global-dropdown-section:not(:last-of-type) {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-light);
   padding-bottom: 10px;
   margin-bottom: 15px;
 }
@@ -1032,7 +1060,7 @@ body.dark tbody tr:nth-child(odd) {
 /* End cssplus break */
 
 body.dark {
-  background: #0a0a1d;
+  background: var(--background-dark);
   color: white;
 
   .app--desktop,
@@ -1095,7 +1123,7 @@ body.dark {
 
   .global-dropdown-body,
   .section-title {
-    background: #0a0a1d;
+    background: var(--background-dark);
   }
 
   .section-title > .button {
@@ -1137,7 +1165,7 @@ body.dark {
 
   .pages {
     .button.page-name {
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--border-light);
     }
   }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -545,16 +545,40 @@ input + input[type='file'] {
   margin: 15px;
 }
 
-/*
-.connector:focus-within,
-.connector:focus,
-.server:focus-within,
-.server:focus,
-.panel:focus-within,
-.panel:focus {
-  border-color: #9f04ff;
+.panel {
+    transition: all .5s;
 }
-*/
+
+.panel--fullscreen {
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: 999;
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    border: 0;
+    display: flex;
+    flex-direction: column;
+
+    .panel-header {
+	border: 0;
+    }
+
+    .panel-body-container {
+	flex: 1;
+
+	.flex {
+	    height: 100%;
+	    flex-direction: column;
+	}
+
+	.panel-out {
+	    width: initial;
+	    height: 400px;
+	}
+    }
+}
 
 .panel--loading {
   animation: pulse 2s infinite ease-out;
@@ -925,8 +949,16 @@ canvas {
   }
 }
 
-th {
-  text-align: left;
+.table {
+    border-collapse: collapse;
+
+    th {
+	text-align: left;
+    }
+
+    th, td {
+	padding: 5px;
+    }
 }
 
 tbody tr:nth-child(odd) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,4 +1,6 @@
 :root {
+  --green: #5dc53b; /* #4fffa6;*/
+
   /* Light theme settings */
   --background-light: #fdfdff;
   --border-light: #d3d3e5;
@@ -6,17 +8,23 @@
   --button-light: #fdfdff;
 
   /* Dark theme settings */
-  --background-dark: #29293c;
-  --border-dark: black;
+  --background-dark: #454f73;
+  --border-dark: #1b1b1d;
   --color-dark: #dfdfdf;
-  --panel-background-dark: #2a2a40;
-  --panel-background-contrast-dark: #26263a;
+  --lighter-dark: #323254;
+  --gutter-dark: var(--lighter-dark);
 
   --sans-serif: 'San Francisco', 'Gadugi', sans-serif;
 }
 
 * {
   box-sizing: border-box;
+}
+
+*,
+*:focus,
+*:hover {
+  outline: none;
 }
 
 body {
@@ -63,7 +71,7 @@ a:hover {
 .main-body {
   flex: 1;
   overflow-y: auto;
-  min-width: 900px;
+  min-width: 920px;
 }
 
 header {
@@ -272,6 +280,14 @@ label.select select {
   /* Since many inputs are within label, keep the label font size small and the input font size normal */
   font-size: initial;
   display: inline-block;
+}
+
+.editor-container .input:focus,
+input.input:not([type='radio']):not([type='file']):focus,
+label.input input:not([type='radio']):not([type='file']):focus,
+select.select:focus,
+label.select select:focus {
+  box-shadow: 0 0 9px var(--border-light);
 }
 
 input + input[type='file'] {
@@ -507,6 +523,7 @@ input + input[type='file'] {
   .connector-name,
   .server-name {
     width: 100%;
+    margin-right: 10px;
   }
 }
 
@@ -744,7 +761,7 @@ input + input[type='file'] {
 
 .text-muted {
   font-size: 0.9rem;
-  color: #333;
+  color: #777;
 }
 
 .tooltip {
@@ -767,6 +784,7 @@ input + input[type='file'] {
   color: #ccc;
   cursor: pointer;
   cursor: hand;
+  padding-left: 5px;
 }
 
 .tooltip:hover .tooltip-body {
@@ -799,7 +817,9 @@ input + input[type='file'] {
   }
 }
 
-.alert > .button--icon {
+.alert > svg {
+  height: 30px;
+  width: 30px;
   margin-right: 15px;
   color: #555;
 }
@@ -866,7 +886,7 @@ input + input[type='file'] {
 }
 
 .text-success {
-  color: #129412;
+  color: var(--green);
 }
 
 .text-failure {
@@ -978,8 +998,8 @@ canvas {
   }
 }
 
-tbody tr:nth-child(odd) {
-  background: var(--darker-light);
+tbody tr {
+  border-top: 1px solid var(--darker-light);
 }
 
 .confirm-wrapper {
@@ -1053,7 +1073,7 @@ tbody tr:nth-child(odd) {
 .global-dropdown-sectionName {
   text-transform: uppercase;
   font-size: 0.9rem;
-  color: #777;
+  color: #999;
 }
 
 .global-dropdown-item {
@@ -1093,6 +1113,14 @@ body.dark label.select select {
   color: var(--color-dark);
 }
 
+body.dark .editor-container .input:focus,
+body.dark input.input:not([type='radio']):not([type='file']):focus,
+body.dark label.input input:not([type='radio']):not([type='file']):focus,
+body.dark select.select:focus,
+body.dark label.select select:focus {
+  box-shadow: 0 0 9px var(--border-dark);
+}
+
 body.dark .server:hover,
 body.dark .connector:hover,
 body.dark .server--expanded,
@@ -1105,8 +1133,8 @@ body.dark .button:hover {
   background: #383852;
 }
 
-body.dark tbody tr:nth-child(odd) {
-  background: var(--panel-background-contrast-dark);
+body.dark tbody tr {
+  border-top-color: var(--lighter-dark);
 }
 /* End cssplus break */
 
@@ -1118,10 +1146,6 @@ body.dark {
   .app--server {
     border: 0;
     height: 100%;
-  }
-
-  .pages {
-    background: #29293c;
   }
 
   .alert {
@@ -1153,36 +1177,35 @@ body.dark {
   }
 
   .button.button--icon.button--primary {
-    color: #4fffa6;
-  }
-
-  .page-name {
-    border-right-color: var(--border-dark);
+    color: var(--green);
   }
 
   .page-name--current {
-    background: #29293c;
+    background: var(--background-dark);
+    border-right: 0;
   }
 
   .global-dropdown-item a {
     color: #61b6ff;
   }
 
+  .ace_gutter-layer,
   .section-title {
-    background: var(--border-dark);
+    background: var(--gutter-dark);
   }
 
   .global-dropdown-body {
     background: var(--background-dark);
+    box-shadow: 0 1px 3px 0 var(--border-dark);
   }
 
   .section-title > .button {
     background: transparent !important;
     border: 0 !important;
+    box-shadow: initial;
   }
 
-  .panel-out,
-  .ace_gutter-layer {
+  .panel-out {
     background: #181824;
   }
 
@@ -1193,7 +1216,7 @@ body.dark {
 
   .panel,
   .editor {
-    background: var(--panel-background-dark);
+    background: var(--background-dark);
   }
 
   .panel {
@@ -1206,7 +1229,7 @@ body.dark {
 
   .panel-head {
     border-bottom: 1px solid var(--border-dark);
-    background: #31314e;
+    background: var(--lighter-dark);
   }
 
   .panel-header--open {
@@ -1241,6 +1264,10 @@ body.dark {
     color: #999;
   }
 
+  .radio .radio-element--selected .input-label {
+    color: var(--color-dark);
+  }
+
   header .toggle .toggle-container {
     border-color: #31314e;
   }
@@ -1252,7 +1279,7 @@ body.dark {
   .card,
   .sidebar,
   .project-name {
-    background: #31314e;
+    background: var(--lighter-dark);
     border-color: var(--border-dark);
   }
 
@@ -1278,6 +1305,7 @@ body.dark {
     color: #e35172;
   }
 
+  .global-dropdown-sectionName,
   .global-dropdown p {
     color: var(--color-dark);
   }

--- a/ui/urlState.tsx
+++ b/ui/urlState.tsx
@@ -22,6 +22,7 @@ export interface UrlState {
   view: 'editor' | 'dashboard' | 'scheduler' | 'settings';
   refreshPeriod?: number;
   expanded?: Array<string>;
+  sidebar?: boolean;
 }
 
 export function getUrlState(): UrlState {
@@ -31,6 +32,7 @@ export function getUrlState(): UrlState {
     fullScreen: getQueryParameter('fullScreen'),
     view: (getQueryParameter('view') || 'editor') as UrlState['view'],
     expanded: getQueryParameter('expanded').split(','),
+    sidebar: getQueryParameter('sidebar') === 'true',
   };
 }
 

--- a/ui/urlState.tsx
+++ b/ui/urlState.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { deepEquals } from '../shared/object';
+import { MODE } from '../shared/constants';
 
 function getQueryParameter(param: String) {
-  const query = window.location.search.substring(1);
+  let query = window.location.search.substring(1);
+  if (MODE === 'desktop') {
+    query = localStorage.getItem('urlstate');
+  }
   const vars = query.split('&');
 
   for (let i = 0; i < vars.length; i++) {
@@ -38,11 +42,7 @@ export function getUrlState(): UrlState {
 
 export function useUrlState(): [UrlState, (a0: Partial<UrlState>) => void] {
   const defaultState = getUrlState();
-  const lastPageIndexKey = 'lastPageIndex:' + defaultState.projectId;
-  const [state, setStateInternal] = React.useState<UrlState>({
-    ...defaultState,
-    page: defaultState.page || +localStorage.getItem(lastPageIndexKey) || 0,
-  });
+  const [state, setStateInternal] = React.useState<UrlState>(defaultState);
 
   React.useEffect(function compareUrlStates() {
     const currentState = getUrlState();
@@ -54,10 +54,7 @@ export function useUrlState(): [UrlState, (a0: Partial<UrlState>) => void] {
         .join('&');
       const newUrl = window.location.pathname + '?' + serialized;
       history.pushState({}, document.title, newUrl);
-
-      if (currentState.page !== state.page) {
-        localStorage.setItem(lastPageIndexKey, String(state.page));
-      }
+      localStorage.setItem('urlstate', serialized);
     }
   });
 

--- a/ui/urlState.tsx
+++ b/ui/urlState.tsx
@@ -18,9 +18,10 @@ function getQueryParameter(param: String) {
 export interface UrlState {
   projectId: string;
   page: number;
-  fullScreen: string;
+  fullScreen?: string;
   view: 'editor' | 'dashboard' | 'scheduler' | 'settings';
   refreshPeriod?: number;
+  expanded?: Array<string>;
 }
 
 export function getUrlState(): UrlState {
@@ -29,6 +30,7 @@ export function getUrlState(): UrlState {
     page: +getQueryParameter('page') || 0,
     fullScreen: getQueryParameter('fullScreen'),
     view: (getQueryParameter('view') || 'editor') as UrlState['view'],
+    expanded: getQueryParameter('expanded').split(','),
   };
 }
 
@@ -45,7 +47,7 @@ export function useUrlState(): [UrlState, (a0: Partial<UrlState>) => void] {
     if (!deepEquals(currentState, state)) {
       const serialized = Object.keys(state)
         .map(function mapKey(k) {
-          return `${k}=${encodeURIComponent(state[k as keyof UrlState])}`;
+          return `${k}=${encodeURIComponent(String(state[k as keyof UrlState]))}`;
         })
         .join('&');
       const newUrl = window.location.pathname + '?' + serialized;

--- a/ui/urlState.tsx
+++ b/ui/urlState.tsx
@@ -18,6 +18,7 @@ function getQueryParameter(param: String) {
 export interface UrlState {
   projectId: string;
   page: number;
+  fullScreen: string;
   view: 'editor' | 'dashboard' | 'scheduler' | 'settings';
   refreshPeriod?: number;
 }
@@ -26,6 +27,7 @@ export function getUrlState(): UrlState {
   return {
     projectId: getQueryParameter('projectId'),
     page: +getQueryParameter('page') || 0,
+    fullScreen: getQueryParameter('fullScreen'),
     view: (getQueryParameter('view') || 'editor') as UrlState['view'],
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,6 +580,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tabler/icons@^1.53.0":
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-1.53.0.tgz#51536e01b343cfaf26b701df306b2c0369769e3c"
+  integrity sha512-Skk1BqXEOEhiRsXJgZBYtjFa/+4dMSFA5UyzTUW20oyyUSd3iizhEWrYt0jT87iFu771gWoqVV2/OGobBcGjgQ==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
Typing is janky because of waiting for updates. This PR does three things for that:

* Wrap http updates in a setTimeout to make the UI not freeze on updates
* Bump the update interval while editing text/code from 125ms to 3s
* Flush updates to text/code onblur and on ctrl-enter in panels

This PR also updates the UI
* Switch to ionic fonts
* Soften the UI
* Drop group labels
* Buttons to automatically create graphs and tables
  * Should probably be more contextual (near Result/Preview section?)
  * Maybe make preview section not black
* Fullscreen mode for panels
* Line wrap on code editor
* Automatic resizing on code editor (bugfix)
* More state synced to url (expanded, sidebar open)

![image](https://user-images.githubusercontent.com/3925912/152627502-ac3b6015-87a4-4a28-b550-4ceda49264b7.png)


Notes:
* [x] Always reading from localstorage on desktop (urlstate) is too slow (changing pages for example)
* [ ] Filter aggregate panel is very tall vertically when exposed