### PR TITLE
Allow alternative fs base directory

### DIFF
--- a/runner/cmd/main.go
+++ b/runner/cmd/main.go
@@ -66,7 +66,7 @@ func main() {
 		settings = runner.DefaultSettings
 	}
 
-	ec := runner.NewEvalContext(*settings)
+	ec := runner.NewEvalContext(*settings, runner.DEFAULT_FS_BASE)
 
 	err = ec.Eval(projectId, panelId)
 	if err != nil {

--- a/runner/database.go
+++ b/runner/database.go
@@ -58,7 +58,7 @@ func (e *Encrypt) decrypt() (string, error) {
 	}
 
 	v := e.Value
-	keyBytes, err := ioutil.ReadFile(path.Join(FS_BASE, ".signingKey"))
+	keyBytes, err := ioutil.ReadFile(path.Join(CONFIG_FS_BASE, ".signingKey"))
 	if err != nil {
 		return "", err
 	}
@@ -347,8 +347,8 @@ func writeRowFromDatabase(dbInfo DatabaseConnectorInfoDatabase, w *JSONArrayWrit
 	return nil
 }
 
-func loadJSONArrayPanel(projectId, panelId string) (chan map[string]interface{}, error) {
-	f := GetPanelResultsFile(projectId, panelId)
+func (ec EvalContext) loadJSONArrayPanel(projectId, panelId string) (chan map[string]interface{}, error) {
+	f := ec.GetPanelResultsFile(projectId, panelId)
 	return loadJSONArrayFile(f)
 }
 
@@ -444,7 +444,7 @@ func (ec EvalContext) EvalDatabasePanel(
 	}
 
 	if panelResultLoader == nil {
-		panelResultLoader = loadJSONArrayPanel
+		panelResultLoader = ec.loadJSONArrayPanel
 	}
 
 	serverId := panel.ServerId
@@ -456,7 +456,7 @@ func (ec EvalContext) EvalDatabasePanel(
 		return err
 	}
 
-	out := GetPanelResultsFile(project.Id, panel.Id)
+	out := ec.GetPanelResultsFile(project.Id, panel.Id)
 	w, err := openTruncate(out)
 	if err != nil {
 		return err

--- a/runner/file.go
+++ b/runner/file.go
@@ -700,7 +700,7 @@ func TransformFile(fileName string, cti ContentTypeInfo, out io.Writer) error {
 	return transformGenericFile(fileName, out)
 }
 
-func evalFilePanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
+func (ec EvalContext) evalFilePanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
 	cti := panel.File.ContentTypeInfo
 	fileName := panel.File.Name
 	server, err := getServer(project, panel.ServerId)
@@ -708,7 +708,7 @@ func evalFilePanel(project *ProjectState, pageIndex int, panel *PanelInfo) error
 		return err
 	}
 
-	out := GetPanelResultsFile(project.Id, panel.Id)
+	out := ec.GetPanelResultsFile(project.Id, panel.Id)
 	w, err := openTruncate(out)
 	if err != nil {
 		return err

--- a/runner/http.go
+++ b/runner/http.go
@@ -170,13 +170,13 @@ func (ec EvalContext) evalHTTPPanel(project *ProjectState, pageIndex int, panel 
 
 	h := panel.Http.Http
 
-	h.Url, err = evalMacros(h.Url, project, pageIndex)
+	h.Url, err = ec.evalMacros(h.Url, project, pageIndex)
 	if err != nil {
 		return err
 	}
 
 	for _, header := range h.Headers {
-		header.Value, err = evalMacros(header.Value, project, pageIndex)
+		header.Value, err = ec.evalMacros(header.Value, project, pageIndex)
 		if err != nil {
 			return err
 		}
@@ -217,7 +217,7 @@ func (ec EvalContext) evalHTTPPanel(project *ProjectState, pageIndex int, panel 
 
 		}
 
-		out := GetPanelResultsFile(project.Id, panel.Id)
+		out := ec.GetPanelResultsFile(project.Id, panel.Id)
 		w, err := openTruncate(out)
 		if err != nil {
 			return err

--- a/runner/literal.go
+++ b/runner/literal.go
@@ -2,9 +2,9 @@ package runner
 
 import "bytes"
 
-func evalLiteralPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
+func (ec EvalContext) evalLiteralPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
 	cti := panel.Literal.ContentTypeInfo
-	out := GetPanelResultsFile(project.Id, panel.Id)
+	out := ec.GetPanelResultsFile(project.Id, panel.Id)
 	w, err := openTruncate(out)
 	if err != nil {
 		return err

--- a/runner/program.go
+++ b/runner/program.go
@@ -95,8 +95,8 @@ func (ec EvalContext) evalProgramPanel(project *ProjectState, pageIndex int, pan
 	}
 	defer os.Remove(tmp.Name())
 
-	resultsFile := getProjectResultsFile(project.Id)
-	panelResultsFile := GetPanelResultsFile(project.Id, panel.Id)
+	resultsFile := ec.getProjectResultsFile(project.Id)
+	panelResultsFile := ec.GetPanelResultsFile(project.Id, panel.Id)
 	jsonIdMap := getIdMapJson(project.Pages[pageIndex])
 	preamble := strings.ReplaceAll(p.Preamble, "$$RESULTS_FILE$$", resultsFile)
 	preamble = strings.ReplaceAll(preamble, "$$PANEL_RESULTS_FILE$$", panelResultsFile)

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -29,7 +29,7 @@ type Settings struct {
 	} `json:"caCerts"`
 }
 
-var SettingsFileDefaultLocation = path.Join(FS_BASE, ".settings")
+var SettingsFileDefaultLocation = path.Join(CONFIG_FS_BASE, ".settings")
 
 var DefaultSettings = &Settings{
 	Id:            uuid.New().String(),


### PR DESCRIPTION
This allows dsq to set a tmp directory so that it can more easily manage cleanup of intermediate files it creates. Currently dsq leaves tons of files in ~/DataStationProjects.