### PR TITLE
Prevent over-eager merging of Scalars of same type into Varied kind

### DIFF
--- a/runner/shape.go
+++ b/runner/shape.go
@@ -267,6 +267,13 @@ func shapeMerge(a Shape, b Shape) Shape {
 		Logln(`Missing type equality condition for %s merge: [%#v] and [%#v].`, b.Kind, a, b)
 	}
 
+	// Both scalars of same type; nothing to merge here
+	if b.Kind == a.Kind && b.Kind == ScalarKind {
+		if a.ScalarShape.Name == b.ScalarShape.Name {
+			return a
+		}
+	}
+
 	// Otherwise is a scalar or dissimilar kind so becomes varied
 	return addUniqueVaried(a, b)
 }

--- a/runner/shape_test.go
+++ b/runner/shape_test.go
@@ -109,6 +109,33 @@ func TestGetShape(t *testing.T) {
 			},
 		},
 		{
+			`[{"a": "9", "b": 1}, {"a": "2", "b": 2}, {"a": 1, "b": 3}]`,
+			Shape{
+				Kind: ArrayKind,
+				ArrayShape: &ArrayShape{
+					Children: Shape{
+						Kind: ObjectKind,
+						ObjectShape: &ObjectShape{
+							Children: map[string]Shape{
+								"a": {
+									Kind: VariedKind,
+									VariedShape: &VariedShape{
+										Children: []Shape{
+											{Kind: ScalarKind, ScalarShape: &ScalarShape{Name: StringScalar}},
+											{Kind: ScalarKind, ScalarShape: &ScalarShape{Name: NumberScalar}},
+										},
+									},
+								},
+								"b": {
+									Kind: ScalarKind, ScalarShape: &ScalarShape{Name: NumberScalar},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			`[{"a": {"b": 1}, "c": "2"}]`,
 			Shape{
 				Kind: ArrayKind,


### PR DESCRIPTION
Hi 👋 

While working on [ob-dsq](https://github.com/fritzgrabo/ob-dsq), I noticed that getting the "Shape" of a JSON file converts shapes of a Scalar kind into a Varied kind when merging Object shapes, even when all sampled rows happen to have the same Scalar kind and type in the merged JSON attribute.

Here's an example to illustrate what I mean:

```shell
$ cat ids-irregular.json 
[
  {"id": 1, "name": "Jorge", "color": "blue"},
  {"id": 2, "name": "Mona", "language": "Ruby"}
]

$ dsq ids-irregular.json "SELECT * FROM {}"
[{"color":"blue","id":"1.0","language":null,"name":"Jorge"},
{"color":null,"id":"2.0","language":"Ruby","name":"Mona"}]
```

Note how the `id` column's shape got merged into a Varied kind (TEXT) even though all rows in the input file are numbers.

I'm not entirely sure if this was done on purpose to err on the side of safety when working with input files that have rows of varying structure? There's [a comment](https://github.com/multiprocessio/datastation/blob/main/runner/shape.go#L270-L271) that seems to indicated that, but I can read it both ways :)

In this PR, I propose to try hard to keep a column's shape untouched if all the sampled rows in the input happen to have the same Scalar kind and type.

```shell
$ dsq ids-irregular.json "SELECT * FROM {}"
[{"color":"blue","id":1,"language":null,"name":"Jorge"},
{"color":null,"id":2,"language":"Ruby","name":"Mona"}]
```

This could help with unexpected results in queries, too. For example, `"SELECT * FROM {} WHERE id=1"` yields an empty result in the unpatched version because `1` doesn't match `"1.0"`.

Please let me know what you think. Thanks!