### PR TITLE
Fix tilde resolution

### DIFF
--- a/runner/file.go
+++ b/runner/file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -705,5 +706,9 @@ func (ec EvalContext) evalFilePanel(project *ProjectState, pageIndex int, panel 
 }
 
 func resolvePath(p string) string {
-	return strings.ReplaceAll(p, "~", HOME)
+	if !strings.HasPrefix(p, "~/") {
+		return p
+	}
+
+	return path.Join(HOME, p[2:])
 }

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -364,6 +364,26 @@ func Test_regressions(t *testing.T) {
 	}
 }
 
+func Test_resolvePath(t *testing.T) {
+	tests := []struct{
+		input string
+		expected string
+	}{
+		{
+			"~/x",
+			HOME + "/x",
+		},
+		{
+			"C:\foo~1\bar",
+			"C:\foo~1\bar",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, resolvePath(test.input))
+	}
+}
+
 // Benchmarks
 
 func Test_transformCSV_BENCHMARK(t *testing.T) {

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -365,8 +365,8 @@ func Test_regressions(t *testing.T) {
 }
 
 func Test_resolvePath(t *testing.T) {
-	tests := []struct{
-		input string
+	tests := []struct {
+		input    string
 		expected string
 	}{
 		{


### PR DESCRIPTION
Tilde resolution should only happen if the string begins with a ~/.

Discovered in https://github.com/multiprocessio/dsq/pull/46.