### PR TITLE
Support CSV parallel encoding

### DIFF
--- a/runner/file_csv.go
+++ b/runner/file_csv.go
@@ -1,0 +1,136 @@
+package runner
+
+import (
+	"encoding/csv"
+	"io"
+	"os"
+	"sync"
+
+	jsonutil "github.com/multiprocessio/go-json"
+)
+
+func transformCSV(in io.Reader, out io.Writer, delimiter rune, parallelEncoding bool) error {
+	r := csv.NewReader(in)
+	r.Comma = delimiter
+	r.FieldsPerRecord = -1
+	r.ReuseRecord = !parallelEncoding
+
+	return withJSONArrayOutWriterFile(out, func(w *jsonutil.StreamEncoder) error {
+		isHeader := true
+		var fields []string
+		row := map[string]any{}
+
+		recordChannel := make(chan []string, preferredParallelism)
+		first := true
+		var wg sync.WaitGroup
+		if parallelEncoding {
+			if _, err := out.Write([]byte{'['}); err != nil {
+				return err
+			}
+			for i := 0; i < preferredParallelism; i++ {
+				go encodeCSVSubroutine(&wg, out, &fields, recordChannel)
+			}
+		}
+
+		for {
+			record, err := r.Read()
+			if err == io.EOF {
+				err = nil
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+
+			if isHeader {
+				for _, field := range record {
+					fields = append(fields, field)
+				}
+				isHeader = false
+				continue
+			}
+
+			if parallelEncoding && !first {
+				recordChannel <- record
+				continue
+			}
+
+			for i, field := range fields {
+				if i < len(record) {
+					row[field] = record[i]
+				} else {
+					row[field] = nil
+				}
+			}
+
+			if parallelEncoding {
+				err = w.SetArray(false).EncodeRow(row) // Encode the first item here so the remaining ones can insert commas freely.
+				if err != nil {
+					return err
+				}
+				w.Close()
+				first = false
+				continue
+			}
+
+			err = w.EncodeRow(row)
+			if err != nil {
+				return err
+			}
+		}
+
+		if parallelEncoding {
+			for {
+				if len(recordChannel) > 0 {
+					continue
+				} else {
+					close(recordChannel)
+					break
+				}
+			}
+			wg.Wait()
+			if _, err := out.Write([]byte{']'}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func transformCSVFile(in string, out io.Writer, delimiter rune, parallelEncoding bool) error {
+	f, err := os.Open(in)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return transformCSV(f, out, delimiter, parallelEncoding)
+}
+
+func encodeCSVSubroutine(wg *sync.WaitGroup, out io.Writer, fields *[]string, recordChannel chan []string) {
+	wg.Add(1)
+	defer wg.Done()
+	w := jsonutil.NewGenericStreamEncoder(out, jsonMarshal, false).SetFirst(false)
+	defer w.Close()
+	row := map[string]any{}
+	var record []string
+	for {
+		record = <-recordChannel
+		if record != nil {
+			for i, f := range *fields {
+				if i >= len(record) {
+					row[f] = nil
+				} else {
+					row[f] = record[i]
+				}
+			}
+			if err := w.EncodeRow(row); err != nil {
+				panic(err) // could we use something like err group and just return the error as normal?
+			}
+		} else {
+			break
+		}
+	}
+}

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -397,7 +397,7 @@ func Test_transformCSV_BENCHMARK(t *testing.T) {
 	assert.Nil(t, err)
 
 	start := time.Now()
-	err = transformCSVFile("taxi.csv", outTmp, ',')
+	err = transformCSVFile("taxi.csv", outTmp, ',', false)
 	assert.Nil(t, err)
 
 	fmt.Printf("transform csv took %s\n", time.Since(start))

--- a/runner/literal.go
+++ b/runner/literal.go
@@ -1,6 +1,8 @@
 package runner
 
-import "bytes"
+import (
+	"bytes"
+)
 
 func (ec EvalContext) evalLiteralPanel(project *ProjectState, pageIndex int, panel *PanelInfo) error {
 	cti := panel.Literal.ContentTypeInfo
@@ -11,5 +13,6 @@ func (ec EvalContext) evalLiteralPanel(project *ProjectState, pageIndex int, pan
 	}
 	defer w.Close()
 	buf := bytes.NewReader([]byte(panel.Content))
-	return TransformReader(buf, "", cti, w)
+
+	return TransformReader(buf, "", cti, w, false) // Assuming literal files are small
 }

--- a/runner/state.go
+++ b/runner/state.go
@@ -81,13 +81,14 @@ const (
 )
 
 type PanelInfo struct {
-	Content    string        `json:"content" db:"content"`
-	Type       PanelInfoType `json:"type" db:"type"`
-	Name       string        `json:"name" db:"name"`
-	Id         string        `json:"id" db:"id"`
-	ServerId   string        `json:"serverId" db:"serverId"`
-	ResultMeta PanelResult   `json:"resultMeta" db:"resultMeta"`
-	PageId     string        `json:"pageId" db:"pageId"`
+	Content          string        `json:"content" db:"content"`
+	Type             PanelInfoType `json:"type" db:"type"`
+	Name             string        `json:"name" db:"name"`
+	Id               string        `json:"id" db:"id"`
+	ServerId         string        `json:"serverId" db:"serverId"`
+	ResultMeta       PanelResult   `json:"resultMeta" db:"resultMeta"`
+	PageId           string        `json:"pageId" db:"pageId"`
+	ParallelEncoding bool          `json:"parallelEncoding" db:"parallelEncoding"`
 	*ProgramPanelInfo
 	*FilePanelInfo
 	*LiteralPanelInfo

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -453,12 +453,14 @@ export class DatabasePanelInfo extends PanelInfo {
     step: number;
     extra: Record<string, string>;
   };
+  parallelEncoding: boolean;
 
   constructor(
     pageId: string,
     panel: Partial<
       DatabasePanelInfo['database'] & { content: string; name: string }
-    > = {}
+    > = {},
+    parallelEncoding?: boolean
   ) {
     super('database', pageId, panel.name || '', panel.content || '');
     this.database = {
@@ -472,20 +474,24 @@ export class DatabasePanelInfo extends PanelInfo {
       step: panel.step || 60,
       extra: panel.extra || {},
     };
+    this.parallelEncoding = parallelEncoding;
   }
 }
 
 export class HTTPPanelInfo extends PanelInfo {
   http: HTTPConnectorInfo;
+  parallelEncoding: boolean;
 
   constructor(
     pageId: string,
     name?: string,
     http?: HTTPConnectorInfo,
-    content?: string
+    content?: string,
+    parallelEncoding?: boolean
   ) {
     super('http', pageId, name, content);
     this.http = http || new HTTPConnectorInfo();
+    this.parallelEncoding = parallelEncoding || false;
   }
 }
 
@@ -570,10 +576,12 @@ export class FilePanelInfo extends PanelInfo {
     name: string;
     content: ArrayBuffer;
   };
+  parallelEncoding: boolean;
 
   constructor(
     pageId: string,
-    panel: Partial<FilePanelInfo['file'] & { panelName: string }> = {}
+    panel: Partial<FilePanelInfo['file'] & { panelName: string }> = {},
+    parallelEncoding?: boolean
   ) {
     super('file', pageId, panel.panelName, '');
     this.file = {
@@ -581,6 +589,7 @@ export class FilePanelInfo extends PanelInfo {
       content: panel.content || new ArrayBuffer(0),
       contentTypeInfo: panel.contentTypeInfo || new ContentTypeInfo(),
     };
+    this.parallelEncoding = parallelEncoding || false;
   }
 }
 

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -459,8 +459,7 @@ export class DatabasePanelInfo extends PanelInfo {
     pageId: string,
     panel: Partial<
       DatabasePanelInfo['database'] & { content: string; name: string }
-    > = {},
-    parallelEncoding?: boolean
+    > = {}
   ) {
     super('database', pageId, panel.name || '', panel.content || '');
     this.database = {
@@ -474,7 +473,7 @@ export class DatabasePanelInfo extends PanelInfo {
       step: panel.step || 60,
       extra: panel.extra || {},
     };
-    this.parallelEncoding = parallelEncoding;
+    this.parallelEncoding = true;
   }
 }
 

--- a/ui/panels/DatabasePanel.tsx
+++ b/ui/panels/DatabasePanel.tsx
@@ -115,17 +115,6 @@ export function DatabasePanelDetails({
           </React.Fragment>
         )}
       </div>
-      <div className="form-row">
-        <Toggle
-          label="Parallel Encoding"
-          value={panel.parallelEncoding}
-          rhsLabel={panel.parallelEncoding ? 'Enabled' : 'Disabled'}
-          onChange={() => {
-            panel.parallelEncoding = !panel.parallelEncoding;
-            updatePanel(panel);
-          }}
-        />
-      </div>
       {connector && (
         <React.Fragment>
           {connector.database.type === 'airtable' && (

--- a/ui/panels/DatabasePanel.tsx
+++ b/ui/panels/DatabasePanel.tsx
@@ -115,6 +115,17 @@ export function DatabasePanelDetails({
           </React.Fragment>
         )}
       </div>
+      <div className="form-row">
+        <Toggle
+          label="Parallel Encoding"
+          value={panel.parallelEncoding}
+          rhsLabel={panel.parallelEncoding ? 'Enabled' : 'Disabled'}
+          onChange={() => {
+            panel.parallelEncoding = !panel.parallelEncoding;
+            updatePanel(panel);
+          }}
+        />
+      </div>
       {connector && (
         <React.Fragment>
           {connector.database.type === 'airtable' && (

--- a/ui/panels/FilePanel.tsx
+++ b/ui/panels/FilePanel.tsx
@@ -9,6 +9,7 @@ import { ContentTypePicker } from '../components/ContentTypePicker';
 import { FileInput } from '../components/FileInput';
 import { FormGroup } from '../components/FormGroup';
 import { ServerPicker } from '../components/ServerPicker';
+import { Toggle } from '../components/Toggle';
 import { ProjectContext } from '../state';
 import { PanelDetailsProps, PanelUIDetails } from './types';
 
@@ -76,6 +77,17 @@ export function FilePanelDetails({
             updatePanel(panel);
           }}
         />
+        <div className="form-row">
+          <Toggle
+            label="Parallel Encoding"
+            value={panel.parallelEncoding}
+            rhsLabel={panel.parallelEncoding ? 'Enabled' : 'Disabled'}
+            onChange={() => {
+              panel.parallelEncoding = !panel.parallelEncoding;
+              updatePanel(panel);
+            }}
+          />
+        </div>
       </FormGroup>
       <ServerPicker
         servers={servers}

--- a/ui/panels/HTTPPanel.tsx
+++ b/ui/panels/HTTPPanel.tsx
@@ -116,6 +116,17 @@ export function HTTPPanelDetails({
             .
           </p>
         </div>
+        <div className="form-row">
+          <Toggle
+            label="Parallel Encoding"
+            value={panel.parallelEncoding}
+            rhsLabel={panel.parallelEncoding ? 'Enabled' : 'Disabled'}
+            onChange={() => {
+              panel.parallelEncoding = !panel.parallelEncoding;
+              updatePanel(panel);
+            }}
+          />
+        </div>
       </FormGroup>
 
       <FormGroup>


### PR DESCRIPTION
- Add a toggle in the UI to enable.
- Add check if file is large enough to encode in parallel.
- Each record will be passed into a channel where they will be consumed by a couple of goroutines.
- Typically encode 3 times faster than normal for large files.

*Maybe we could do a generic goroutine and apply it to all the other file types and databases. This only involves changing the channel type. 