### PR TITLE
All panels autocomplete

### DIFF
--- a/ui/Updates.tsx
+++ b/ui/Updates.tsx
@@ -2,8 +2,11 @@ import * as React from 'react';
 import { SITE_ROOT, VERSION } from '../shared/constants';
 import { request } from '../shared/http';
 import log from '../shared/log';
+import { newId } from '../shared/object';
 import { ContentTypeInfo } from '../shared/state';
 import { SettingsContext } from './Settings';
+
+const s = newId();
 
 export function Updates() {
   const { state: settings } = React.useContext(SettingsContext);
@@ -15,7 +18,7 @@ export function Updates() {
           const updates = await request(
             window.fetch,
             'GET',
-            `${SITE_ROOT}/api/updates?version=${VERSION}&i=${settings.id}`,
+            `${SITE_ROOT}/api/updates?version=${VERSION}&i=${settings.id}&s=${s}`,
             new ContentTypeInfo(),
             [],
             '',

--- a/ui/components/CodeEditor.tsx
+++ b/ui/components/CodeEditor.tsx
@@ -44,6 +44,14 @@ export function skipWhitespaceForward(it: Ace.TokenIterator) {
   }
 }
 
+const AUTOCOMPLETE_MAP: Record<
+  string,
+  (
+    tokenIteratorFactory: () => Ace.TokenIterator,
+    prefix: string
+  ) => Array<Ace.Completion>
+> = {};
+
 export function CodeEditor({
   value,
   onChange,
@@ -77,6 +85,10 @@ export function CodeEditor({
   const {
     state: { theme, autocompleteDisabled },
   } = React.useContext(SettingsContext);
+
+  if (autocomplete) {
+    AUTOCOMPLETE_MAP[id] = autocomplete;
+  }
 
   const [editorRef, setEditorRef] = React.useState<AceEditor>(null);
   const debounced = useDebouncedCallback(onChange, INPUT_SYNC_PERIOD);
@@ -136,15 +148,10 @@ export function CodeEditor({
         prefix: string,
         callback: Ace.CompleterCallback
       ) => {
-        // This gets registered globally which is kind of weird.  //
-        // So it needs to check again that the currently editing editor
-        // is the one attached to this callback.
-        if (!autocomplete || (editorRef.editor as unknown) !== editor) {
-          return callback(null, []);
-        }
-
+        // This gets set/called in a global context so we need to figure out which panel is actually calling it.
         try {
           const factory = () => new TokenIterator(session, pos.row, pos.column);
+          const autocomplete = AUTOCOMPLETE_MAP[(editor as any).container.id];
           return callback(null, autocomplete(factory, prefix));
         } catch (e) {
           log.error(e);


### PR DESCRIPTION
There was a bug before this that only the last panel had autocomplete.

This fixes autocomplete so all code/database panels appropriately autocomplete and only have the right functions for their language/vendor.