### PR TITLE
Add basic format support for sql

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "shape": "npm:@multiprocess/shape",
     "source-map-support": "^0.5.21",
+    "sql-formatter": "^6.1.1",
     "tmp-promise": "^3.0.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6970,6 +6970,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+sql-formatter@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-6.1.1.tgz#ec9d4c6fc90c2839885cf36ca7b0755a84527802"
+  integrity sha512-NiUP90vNb6NjQryWz0bPsvv4BTqe/wY75mRbh2E6M1kKZIoCKtueeKIDMQBB+RI8pjxVUQy7e35JUXQj6YYonQ==
+  dependencies:
+    argparse "^2.0.1"
+
 ssf@~0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"


### PR DESCRIPTION
This format button is only available when editing SQL. In the future it might make sense to bring in prettier and its plugins but for now SQL is the big deal.

Closes https://github.com/multiprocessio/datastation/issues/172 

![Screenshot 2022-05-22 135637](https://user-images.githubusercontent.com/3925912/169708967-11be9195-8ce5-4227-acc2-e4adf9691381.png)
