### PR TITLE
add xlsm extension to mime detector

### DIFF
--- a/runner/file.go
+++ b/runner/file.go
@@ -646,7 +646,7 @@ func GetMimeType(fileName string, ct ContentTypeInfo) MimeType {
 		return JSONLinesMimeType
 	case ".cjson":
 		return JSONConcatMimeType
-	case ".xls", ".xlsx":
+	case ".xls", ".xlsx", ".xlsm":
 		return ExcelMimeType
 	case ".ods":
 		return OpenOfficeSheetMimeType


### PR DESCRIPTION
Tried to run `dsq` on an Excel workbook with macros enabled, got a "unknown mimetype for file" error, which I traced back to this.