### PR TITLE
Optionally convert numbers in CSV files

### DIFF
--- a/runner/database_google_sheets.go
+++ b/runner/database_google_sheets.go
@@ -26,7 +26,7 @@ func writeGoogleSheet(sheet *sheets.ValueRange, w *jsonutil.StreamEncoder) error
 			continue
 		}
 
-		recordToMap(row, &header, rawRow)
+		recordToMap(row, &header, rawRow, false)
 
 		err := w.EncodeRow(row)
 		if err != nil {

--- a/runner/file.go
+++ b/runner/file.go
@@ -711,11 +711,9 @@ func TransformFile(fileName string, cti ContentTypeInfo, out *bufio.Writer) erro
 	case JSONMimeType:
 		return transformJSONFile(fileName, out)
 	case CSVMimeType:
-		// TODO: Use "convert numbers" flag from content type info
-		return transformCSVFile(fileName, out, ',', false)
+		return transformCSVFile(fileName, out, ',', cti.ConvertNumbers)
 	case TSVMimeType:
-		// TODO: Use "convert numbers" flag from content type info
-		return transformCSVFile(fileName, out, '\t', false)
+		return transformCSVFile(fileName, out, '\t', cti.ConvertNumbers)
 	case ExcelMimeType, ExcelOpenXMLMimeType:
 		return transformXLSXFile(fileName, out)
 	case ParquetMimeType:

--- a/runner/http.go
+++ b/runner/http.go
@@ -255,9 +255,11 @@ func TransformReader(r *bufio.Reader, fileName string, cti ContentTypeInfo, out 
 	case JSONMimeType:
 		return transformJSON(r, out)
 	case CSVMimeType:
-		return transformCSV(r, out, ',')
+		// TODO: Use "convert numbers" flag from content type info
+		return transformCSV(r, out, ',', false)
 	case TSVMimeType:
-		return transformCSV(r, out, '\t')
+		// TODO: Use "convert numbers" flag from content type info
+		return transformCSV(r, out, '\t', false)
 	case ExcelMimeType, ExcelOpenXMLMimeType:
 		r, err := excelize.OpenReader(r)
 		if err != nil {

--- a/runner/http.go
+++ b/runner/http.go
@@ -255,11 +255,9 @@ func TransformReader(r *bufio.Reader, fileName string, cti ContentTypeInfo, out 
 	case JSONMimeType:
 		return transformJSON(r, out)
 	case CSVMimeType:
-		// TODO: Use "convert numbers" flag from content type info
-		return transformCSV(r, out, ',', false)
+		return transformCSV(r, out, ',', cti.ConvertNumbers)
 	case TSVMimeType:
-		// TODO: Use "convert numbers" flag from content type info
-		return transformCSV(r, out, '\t', false)
+		return transformCSV(r, out, '\t', cti.ConvertNumbers)
 	case ExcelMimeType, ExcelOpenXMLMimeType:
 		r, err := excelize.OpenReader(r)
 		if err != nil {

--- a/runner/state.go
+++ b/runner/state.go
@@ -65,6 +65,7 @@ var defaultServerInfo = ServerInfo{
 type ContentTypeInfo struct {
 	Type             string `json:"type" db:"type"`
 	CustomLineRegexp string `json:"customLineRegexp" db:"customLineRegexp"`
+	ConvertNumbers   bool   `json:"convertNumbers" db:"convertNumbers"`
 }
 
 var defaultContentTypeInfo = ContentTypeInfo{}


### PR DESCRIPTION
Resolves #264 

Here's what I got so far. I gave this a try from `dsq` (PR coming soon) and it works well!

```shell
$ cat ~/scores.csv
Name,Score
Fritz,90
Rainer,95
Fountainer,100

$ ./dsq --schema --pretty ~/scores.csv
Array of
  Object of
    Name of
      string
    Score of
      string

$ ./dsq --schema --pretty --convert-numbers ~/scores.csv
Array of
  Object of
    Name of
      string
    Score of
      number
```

At this point, I'm not sure if I should add a `convertNumbers` flag to the literal and http panels too, or just assume `false` there. Theoretically, it'd make sense to convert numbers from downloaded CSV files, too?

Let me know what you think. Thanks!