### PR TITLE
Add an optional "workgroup" field to the Amazon Athena connection.

### DIFF
--- a/runner/database_athena.go
+++ b/runner/database_athena.go
@@ -61,6 +61,9 @@ func (ec EvalContext) evalAthena(panel *PanelInfo, dbInfo DatabaseConnectorInfoD
 	svc := athena.New(sess, cfg)
 	var s athena.StartQueryExecutionInput
 	s.SetQueryString(panel.Content)
+	if workgroup, ok := dbInfo.Extra["workgroup"]; ok && len(workgroup) > 0 {
+		s.SetWorkGroup(workgroup)
+	}
 
 	var q athena.QueryExecutionContext
 	q.SetDatabase(dbInfo.Database)

--- a/scripts/ci/prepare_macos.sh
+++ b/scripts/ci/prepare_macos.sh
@@ -26,7 +26,7 @@ yarn
 # Install ODBC Driver
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
-HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18
+HOMEBREW_ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18
 
 # Install docker using colima (not present because of licenses)
 brew install colima

--- a/ui/connectors/AthenaDetails.tsx
+++ b/ui/connectors/AthenaDetails.tsx
@@ -57,6 +57,17 @@ export function AthenaDetails(props: {
             {...props}
           />
         </div>
+        <div className="form-row">
+          <Input
+            label="Workgroup"
+            value={connector.database.extra.workgroup}
+            onChange={(value: string) => {
+              connector.database.extra.workgroup = value;
+              updateConnector(connector);
+            }}
+            {...props}
+          />
+        </div>
       </FormGroup>
     </>
   );


### PR DESCRIPTION
This change allows the use of workgroups other than the default "primary" workgroup.

about Amazon Athena workgroups -> [How workgroups work - Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/user-created-workgroups.html)